### PR TITLE
Add copy response button to graphql-network-inspector

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.0.4",
-    "@testing-library/user-event": "^7.1.2",
     "@types/chrome": "^0.0.122",
     "@types/dedent": "^0.7.0",
     "@types/jest": "^24.0.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@types/react-table": "^7.0.22",
+    "copy-to-clipboard": "^3.3.1",
     "graphql": "^15.3.0",
     "graphql-tag": "^2.11.0",
     "mergeby": "^2.0.1",

--- a/src/components/CopyButton/CopyButton.module.css
+++ b/src/components/CopyButton/CopyButton.module.css
@@ -1,0 +1,16 @@
+.container {
+  position: absolute;
+  left: 400px;
+  top: 40px;
+}
+
+.button {
+  font-size: 1.25rem;
+  background: #5261d0;
+  border: 1px solid #5261d0;
+  padding: 0.5rem 1rem;
+  color: white;
+  font-weight: 600;
+  border-radius: 5px;
+  cursor: pointer;
+}

--- a/src/components/CopyButton/CopyButton.module.css
+++ b/src/components/CopyButton/CopyButton.module.css
@@ -1,7 +1,7 @@
 .container {
   position: absolute;
   right: 15px;
-  top: 40px;
+  top: 15px;
 }
 
 .button {

--- a/src/components/CopyButton/CopyButton.module.css
+++ b/src/components/CopyButton/CopyButton.module.css
@@ -1,16 +1,21 @@
 .container {
   position: absolute;
-  left: 400px;
+  right: 15px;
   top: 40px;
 }
 
 .button {
-  font-size: 1.25rem;
-  background: #5261d0;
-  border: 1px solid #5261d0;
+  font-size: 1.2rem;
+  background: #505356;
+  border: none;
   padding: 0.5rem 1rem;
   color: white;
   font-weight: 600;
   border-radius: 5px;
   cursor: pointer;
+  outline: 0;
+}
+
+.button:active {
+  background: #6c6c70;
 }

--- a/src/components/CopyButton/index.test.tsx
+++ b/src/components/CopyButton/index.test.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CopyButton } from "./";
+
+const textToCopy = "Hello";
+
+test("renders a <CopyButton/>", () => {
+  const { getByTestId } = render(<CopyButton textToCopy={textToCopy} />);
+  expect(getByTestId("copy-button")).toHaveTextContent("Copy");
+});
+
+test("fires an event when clicked", () => {
+  const { getByTestId } = render(<CopyButton textToCopy={textToCopy} />);
+  userEvent.click(getByTestId("copy-button"));
+  expect(getByTestId("copy-button")).toHaveTextContent("Copied!");
+});

--- a/src/components/CopyButton/index.test.tsx
+++ b/src/components/CopyButton/index.test.tsx
@@ -5,6 +5,10 @@ import { CopyButton } from "./";
 
 const textToCopy = "Hello";
 
+jest.mock("copy-to-clipboard", () => {
+  return jest.fn();
+});
+
 test("renders a <CopyButton/>", () => {
   const { getByTestId } = render(<CopyButton textToCopy={textToCopy} />);
   expect(getByTestId("copy-button")).toHaveTextContent("Copy");

--- a/src/components/CopyButton/index.test.tsx
+++ b/src/components/CopyButton/index.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { render, fireEvent } from "@testing-library/react";
 import { CopyButton } from "./";
 
 const textToCopy = "Hello";
@@ -16,6 +15,6 @@ test("renders a <CopyButton/>", () => {
 
 test("fires an event when clicked", () => {
   const { getByTestId } = render(<CopyButton textToCopy={textToCopy} />);
-  userEvent.click(getByTestId("copy-button"));
+  fireEvent.click(getByTestId("copy-button"));
   expect(getByTestId("copy-button")).toHaveTextContent("Copied!");
 });

--- a/src/components/CopyButton/index.tsx
+++ b/src/components/CopyButton/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import copy from "copy-to-clipboard";
 import classes from "./CopyButton.module.css";
+
 type CopyButtonProps = {
   textToCopy: string;
 };

--- a/src/components/CopyButton/index.tsx
+++ b/src/components/CopyButton/index.tsx
@@ -12,7 +12,7 @@ export const CopyButton = (props: CopyButtonProps) => {
 
   useEffect(() => {
     if (copied) {
-      let timeout = setTimeout(() => setCopied(false), 2000);
+      const timeout = setTimeout(() => setCopied(false), 2000);
 
       return () => {
         clearTimeout(timeout);

--- a/src/components/CopyButton/index.tsx
+++ b/src/components/CopyButton/index.tsx
@@ -1,0 +1,35 @@
+import React, { useState, useEffect } from "react";
+import copy from "copy-to-clipboard";
+import classes from "./CopyButton.module.css";
+type CopyButtonProps = {
+  textToCopy: string;
+};
+
+export const CopyButton = (props: CopyButtonProps) => {
+  const [copied, setCopied] = useState(false);
+  const { textToCopy } = props;
+
+  useEffect(() => {
+    if (copied) {
+      let timeout = setTimeout(() => setCopied(false), 2000);
+
+      return () => {
+        clearTimeout(timeout);
+      };
+    }
+  });
+  return (
+    <div className={classes.container}>
+      <button
+        className={classes.button}
+        data-testid="copy-button"
+        onClick={() => {
+          copy(textToCopy);
+          setCopied(true);
+        }}
+      >
+        {copied ? "Copied!" : "Copy"}
+      </button>
+    </div>
+  );
+};

--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -5,11 +5,11 @@ import { Tabs, Tab } from "./index";
 const tabs: Tab[] = [
   {
     title: "Tab One",
-    component: <div>I am tab one</div>,
+    component: () => <div>I am tab one</div>,
   },
   {
     title: "Tab Two",
-    component: <div>I am tab two</div>,
+    component: () => <div>I am tab two</div>,
   },
 ];
 

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -3,7 +3,7 @@ import classes from "./Tabs.module.css";
 
 export type Tab = {
   title: string;
-  component: React.ReactNode;
+  component: () => React.ReactNode;
 };
 
 export type TabsProps = {
@@ -30,7 +30,7 @@ export const Tabs = (props: TabsProps) => {
         ))}
       </div>
       <div className={`${classes.tabContent} scroll`}>
-        {tabs[activeTab].component}
+        {tabs[activeTab].component()}
       </div>
     </div>
   );

--- a/src/containers/NetworkPanel/NetworkPanel.module.css
+++ b/src/containers/NetworkPanel/NetworkPanel.module.css
@@ -5,6 +5,12 @@
 
 .query {
   border-bottom: 1px solid #3d4043;
+  position: relative;
+  overflow: hidden;
+}
+
+.response {
+  position: relative;
 }
 
 .closeButton {

--- a/src/containers/NetworkPanel/index.tsx
+++ b/src/containers/NetworkPanel/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import copy from "copy-to-clipboard";
 import classes from "./NetworkPanel.module.css";
 import { CodeBlock } from "../../components/CodeBlock";
 import { JsonView } from "../../components/JsonView";
@@ -57,16 +58,25 @@ export const NetworkPanel = (props: NetworkPanelProps) => {
           {
             title: "Response (Raw)",
             component: (
-              <CodeBlock
-                text={
-                  safeJson.stringify(
-                    safeJson.parse(responseBody) || {},
-                    undefined,
-                    4
-                  ) || ""
-                }
-                language={"json"}
-              />
+              <>
+                <CodeBlock
+                  text={
+                    safeJson.stringify(
+                      safeJson.parse(responseBody) || {},
+                      undefined,
+                      4
+                    ) || ""
+                  }
+                  language={"json"}
+                />
+                <button
+                  onClick={() => {
+                    copy(`${safeJson.parse(responseBody)}`);
+                  }}
+                >
+                  Copy Response
+                </button>
+              </>
             ),
           },
         ]}

--- a/src/containers/NetworkPanel/index.tsx
+++ b/src/containers/NetworkPanel/index.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import copy from "copy-to-clipboard";
 import classes from "./NetworkPanel.module.css";
 import { CodeBlock } from "../../components/CodeBlock";
 import { JsonView } from "../../components/JsonView";
 import { Tabs } from "../../components/Tabs";
 import { CloseIcon } from "../../components/Icons/CloseIcon";
 import { NetworkRequest } from "../../hooks/useNetworkMonitor";
+import { CopyButton } from "../../components/CopyButton";
 import * as safeJson from "../../helpers/safeJson";
 
 export type NetworkPanelProps = {
@@ -37,6 +37,7 @@ export const NetworkPanel = (props: NetworkPanelProps) => {
               <div>
                 {requestBody.map(({ query, variables }) => (
                   <div key={query} className={classes.query}>
+                    <CopyButton textToCopy={query} />
                     <h2 className={classes.subtitle}>Request</h2>
                     <CodeBlock text={query} language={"graphql"} />
                     <h2 className={classes.subtitle}>Variables</h2>
@@ -53,12 +54,22 @@ export const NetworkPanel = (props: NetworkPanelProps) => {
           },
           {
             title: "Response",
-            component: <JsonView src={safeJson.parse(responseBody) || {}} />,
+            component: (
+              <>
+                <JsonView src={safeJson.parse(responseBody) || {}} />
+                <CopyButton
+                  textToCopy={`${safeJson.stringify(responseBody)}`}
+                />
+              </>
+            ),
           },
           {
             title: "Response (Raw)",
             component: (
               <>
+                <CopyButton
+                  textToCopy={`${safeJson.stringify(responseBody)}`}
+                />
                 <CodeBlock
                   text={
                     safeJson.stringify(
@@ -69,13 +80,6 @@ export const NetworkPanel = (props: NetworkPanelProps) => {
                   }
                   language={"json"}
                 />
-                <button
-                  onClick={() => {
-                    copy(`${safeJson.parse(responseBody)}`);
-                  }}
-                >
-                  Copy Response
-                </button>
               </>
             ),
           },

--- a/src/containers/NetworkPanel/index.tsx
+++ b/src/containers/NetworkPanel/index.tsx
@@ -59,10 +59,10 @@ export const NetworkPanel = (props: NetworkPanelProps) => {
               const formattedJson =
                 safeJson.stringify(parsedResponse, undefined, 4) || "";
               return (
-                <>
+                <div className={classes.response}>
                   <JsonView src={parsedResponse} />
                   <CopyButton textToCopy={formattedJson} />
-                </>
+                </div>
               );
             },
           },
@@ -73,10 +73,10 @@ export const NetworkPanel = (props: NetworkPanelProps) => {
               const formattedJson =
                 safeJson.stringify(parsedResponse, undefined, 4) || "";
               return (
-                <>
+                <div className={classes.response}>
                   <CopyButton textToCopy={formattedJson} />
                   <CodeBlock text={formattedJson} language={"json"} />
-                </>
+                </div>
               );
             },
           },

--- a/src/containers/NetworkPanel/index.tsx
+++ b/src/containers/NetworkPanel/index.tsx
@@ -33,7 +33,7 @@ export const NetworkPanel = (props: NetworkPanelProps) => {
         tabs={[
           {
             title: "Request",
-            component: (
+            component: () => (
               <div>
                 {requestBody.map(({ query, variables }) => (
                   <div key={query} className={classes.query}>
@@ -54,34 +54,31 @@ export const NetworkPanel = (props: NetworkPanelProps) => {
           },
           {
             title: "Response",
-            component: (
-              <>
-                <JsonView src={safeJson.parse(responseBody) || {}} />
-                <CopyButton
-                  textToCopy={`${safeJson.stringify(responseBody)}`}
-                />
-              </>
-            ),
+            component: () => {
+              const parsedResponse = safeJson.parse(responseBody) || {};
+              const formattedJson =
+                safeJson.stringify(parsedResponse, undefined, 4) || "";
+              return (
+                <>
+                  <JsonView src={parsedResponse} />
+                  <CopyButton textToCopy={formattedJson} />
+                </>
+              );
+            },
           },
           {
             title: "Response (Raw)",
-            component: (
-              <>
-                <CopyButton
-                  textToCopy={`${safeJson.stringify(responseBody)}`}
-                />
-                <CodeBlock
-                  text={
-                    safeJson.stringify(
-                      safeJson.parse(responseBody) || {},
-                      undefined,
-                      4
-                    ) || ""
-                  }
-                  language={"json"}
-                />
-              </>
-            ),
+            component: () => {
+              const parsedResponse = safeJson.parse(responseBody) || {};
+              const formattedJson =
+                safeJson.stringify(parsedResponse, undefined, 4) || "";
+              return (
+                <>
+                  <CopyButton textToCopy={formattedJson} />
+                  <CodeBlock text={formattedJson} language={"json"} />
+                </>
+              );
+            },
           },
         ]}
       />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1672,11 +1672,6 @@
     "@babel/runtime" "^7.11.2"
     "@testing-library/dom" "^7.26.0"
 
-"@testing-library/user-event@^7.1.2":
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-7.2.1.tgz#2ad4e844175a3738cb9e7064be5ea070b8863a1c"
-  integrity sha512-oZ0Ib5I4Z2pUEcoo95cT1cr6slco9WY7yiPpG+RGNkj8YcYgJnM7pXmYmorNOReh8MIGcKSqXyeGjxnr8YiZbA==
-
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3613,6 +3613,13 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copy-to-clipboard@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
+  integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==
+  dependencies:
+    toggle-selection "^1.0.6"
+
 core-js-compat@^3.6.2:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.6.5.tgz#2a51d9a4e25dfd6e690251aa81f99e3c05481f1c"
@@ -11081,6 +11088,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+toggle-selection@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
+  integrity sha1-bkWxJj8gF/oKzH2J14sVuL932jI=
 
 toidentifier@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Draft PR to add a copy response button to the graphql-network inspector.

### Questions

- Is it worth including this button in `Response` and `Response (Raw)` tabs or having a button next to the bin button?
- Perhaps we can add some sort of way for the user to know that clicking on the button has succesfully copied the contents? Might be overboard though!

### Todos

- [x] Tests
- [x] Styling of button
