### PR TITLE
Fragment name being used instead of query/mutation

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,6 +7,6 @@
     "128": "icon.png"
   },
   "manifest_version": 2,
-  "permissions": ["webRequest", "activeTab"],
+  "permissions": [],
   "devtools_page": "devtools/devtools.html"
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,0 @@
-# https://www.robotstxt.org/robotstxt.html
-User-agent: *
-Disallow:

--- a/src/helpers/graphqlHelpers.ts
+++ b/src/helpers/graphqlHelpers.ts
@@ -28,13 +28,15 @@ export const getPrimaryOperation = (
     const request = JSON.parse(requestBody || "");
     const postData = Array.isArray(request) ? request : [request];
     const documentNode = parseGraphqlQuery(postData[0].query) as any;
+    const totalDefinitions = documentNode.definitions.length;
+    const lastDefinition = documentNode.definitions[totalDefinitions - 1];
     const operationName =
-      documentNode.definitions[0]?.name?.value ||
-      documentNode.definitions[0].selectionSet.selections[0].name.value;
+      lastDefinition?.name?.value ||
+      lastDefinition.selectionSet.selections[0].name.value;
 
     return {
       operationName,
-      operation: documentNode.definitions[0]?.operation,
+      operation: lastDefinition?.operation,
     };
   } catch (e) {
     return null;

--- a/src/mocks/mock-requests.ts
+++ b/src/mocks/mock-requests.ts
@@ -40,6 +40,11 @@ export const mockRequests = [
     request: [
       {
         query: `
+          fragment NameParts on Person {
+            firstName
+            lastName
+          }
+
           query getMovie($title: String) {
             getMovie(title: $title) {
               id


### PR DESCRIPTION
When a fragment is used, its name is taking place of the query/mutation when displayed in the sidebar. This PR fixes that by reading the correct query/mutation name in all cases.