### PR TITLE
Historic Logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-app",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "dependencies": {
     "classnames": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@tailwindcss/forms": "^0.3.3",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.0.4",
-    "@types/chrome": "^0.0.122",
+    "@types/chrome": "^0.0.154",
     "@types/dedent": "^0.7.0",
     "@types/jest": "^24.0.0",
     "@types/node": "^12.0.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "GraphQL Network Inspector",
-  "version": "2.0",
+  "version": "2.01",
   "description": "Simple and clean network inspector for GraphQL",
   "icons": {
     "128": "icon.png"

--- a/src/containers/Main/Main.test.tsx
+++ b/src/containers/Main/Main.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, fireEvent, within } from "@testing-library/react";
+import { render, fireEvent, within, waitFor } from "@testing-library/react";
 import { Main } from "./index";
 import { chromeProvider } from "../../services/chromeProvider";
 import { mockChrome } from "../../mocks/mock-chrome";
@@ -37,48 +37,72 @@ describe("Main", () => {
     mockChromeProvider.mockReturnValue(mockChrome);
   });
 
-  it("renders the table only by default", () => {
-    const { queryByTestId } = render(<Main />);
+  it("renders the table only by default", async () => {
+    const { queryByTestId, getByText } = render(<Main />);
+
+    await waitFor(() => {
+      expect(getByText(/getMovie/i)).toBeInTheDocument();
+    });
 
     expect(queryByTestId("network-table")).toBeInTheDocument();
     expect(queryByTestId("network-tabs")).not.toBeInTheDocument();
   });
 
-  it("opens the side panel when clicking a table row", () => {
-    const { getAllByText, getByTestId } = render(<Main />);
+  it("opens the side panel when clicking a table row", async () => {
+    const { getByText, getByTestId } = render(<Main />);
 
-    fireEvent.click(getAllByText(/getMovie/i)[0]);
+    await waitFor(() => {
+      expect(getByText(/getMovie/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(getByText(/getMovie/i));
 
     expect(getByTestId("network-tabs")).toBeInTheDocument();
   });
 
-  it("closes the side panel when clicking the 'x' button", () => {
-    const { queryByTestId, getByTestId, getAllByText } = render(<Main />);
+  it("closes the side panel when clicking the 'x' button", async () => {
+    const { queryByTestId, getByTestId, getByText } = render(<Main />);
 
-    fireEvent.click(getAllByText(/getMovie/i)[0]);
+    await waitFor(() => {
+      expect(getByText(/getMovie/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(getByText(/getMovie/i));
     fireEvent.click(getByTestId("close-side-panel"));
 
     expect(queryByTestId("network-tabs")).not.toBeInTheDocument();
   });
 
-  it("renders all network data within the table", () => {
+  it("renders all network data within the table", async () => {
     const { queryByTestId } = render(<Main />);
     const table = queryByTestId("network-table");
     if (!table) {
       throw new Error("Table not found in dom");
     }
-    const { queryAllByRole } = within(table);
+    const { queryAllByRole, getByText } = within(table);
+
+    await waitFor(() => {
+      expect(getByText(/getMovie/i)).toBeInTheDocument();
+    });
 
     expect(queryAllByRole("row")).toHaveLength(6);
   });
 
-  it("renders correct values for each column within the table", () => {
+  it("renders correct values for each column within the table", async () => {
     const { queryByTestId } = render(<Main />);
     const table = queryByTestId("network-table");
     if (!table) {
       throw new Error("Table not found in dom");
     }
-    const { queryAllByRole: queryAllByRoleWithinTable } = within(table);
+    const {
+      queryAllByRole: queryAllByRoleWithinTable,
+      getByText: getByTextWithinTable,
+    } = within(table);
+
+    await waitFor(() => {
+      expect(getByTextWithinTable(/getMovie/i)).toBeInTheDocument();
+    });
+
     const row = queryAllByRoleWithinTable("row")[1];
     const { queryByTestId: queryByTestIdWithinRow } = within(row);
 
@@ -92,22 +116,30 @@ describe("Main", () => {
     expect(queryByTestIdWithinRow("column-size")).toHaveTextContent("3.36 kB");
   });
 
-  it("clears the table of all network data when clicking the clear button", () => {
+  it("clears the table of all network data when clicking the clear button", async () => {
     const { queryByTestId } = render(<Main />);
     const table = queryByTestId("network-table");
-    const { getByTestId, queryAllByRole } = within(table!);
+    const { getByTestId, queryAllByRole, getByText } = within(table!);
+
+    await waitFor(() => {
+      expect(getByText(/getMovie/i)).toBeInTheDocument();
+    });
 
     fireEvent.click(getByTestId("clear-network-table"));
 
     expect(queryAllByRole("row")).toHaveLength(1);
   });
 
-  it("clears the table of all network data when reloading", () => {
+  it("clears the table of all network data when reloading", async () => {
     const triggerOnNavigated = mockOnNavigated();
 
     const { queryByTestId } = render(<Main />);
     const table = queryByTestId("network-table");
-    const { queryAllByRole } = within(table!);
+    const { queryAllByRole, getByText } = within(table!);
+
+    await waitFor(() => {
+      expect(getByText(/getMovie/i)).toBeInTheDocument();
+    });
 
     act(() => {
       triggerOnNavigated();
@@ -116,12 +148,16 @@ describe("Main", () => {
     expect(queryAllByRole("row")).toHaveLength(1);
   });
 
-  it("does not clear the table of all network data when reloading and preserve log checked", () => {
+  it("does not clear the table of all network data when reloading and preserve log checked", async () => {
     const triggerOnNavigated = mockOnNavigated();
 
     const { getByTestId, queryByTestId } = render(<Main />);
     const table = queryByTestId("network-table");
-    const { queryAllByRole } = within(table!);
+    const { queryAllByRole, getByText } = within(table!);
+
+    await waitFor(() => {
+      expect(getByText(/getMovie/i)).toBeInTheDocument();
+    });
 
     act(() => {
       fireEvent.click(getByTestId("preserve-log-checkbox"));
@@ -134,11 +170,15 @@ describe("Main", () => {
     expect(queryAllByRole("row")).toHaveLength(6);
   });
 
-  it("filters network data with the given search query", () => {
+  it("filters network data with the given search query", async () => {
     const { getByTestId, queryByTestId } = render(<Main />);
     const table = queryByTestId("network-table");
-    const { queryAllByRole } = within(table!);
+    const { queryAllByRole, getByText } = within(table!);
     const filterInput = getByTestId("filter-input") as HTMLInputElement;
+
+    await waitFor(() => {
+      expect(getByText(/getMovie/i)).toBeInTheDocument();
+    });
 
     act(() => {
       fireEvent.change(filterInput, {

--- a/src/mocks/mock-chrome.ts
+++ b/src/mocks/mock-chrome.ts
@@ -16,12 +16,11 @@ export const mockChrome = {
       themeName: "dark",
     },
     network: {
+      getHAR: (cb) => {
+        cb({ entries: mockRequests } as any);
+      },
       onRequestFinished: {
         addListener: (cb) => {
-          mockRequests.forEach((mockRequest) => {
-            cb(mockRequest as any);
-          });
-
           // On press key "1", add more mock requests to app
           const handleKeydown = (e: KeyboardEvent) => {
             if (e.code === "Digit1") {

--- a/src/services/networkMonitor.ts
+++ b/src/services/networkMonitor.ts
@@ -1,9 +1,5 @@
 import { chromeProvider } from "./chromeProvider";
 
-// On first load of app, try to get previous network activity
-// No requests would have loaded at this point?
-// Do we need to check against existing requests to avoid duplication?
-
 export const getHAR = async (): Promise<chrome.devtools.network.HARLog> => {
   const chrome = chromeProvider();
   return new Promise((resolve) => {

--- a/src/services/networkMonitor.ts
+++ b/src/services/networkMonitor.ts
@@ -1,9 +1,23 @@
 import { chromeProvider } from "./chromeProvider";
 
+// On first load of app, try to get previous network activity
+// No requests would have loaded at this point?
+// Do we need to check against existing requests to avoid duplication?
+
+export const getHAR = async (): Promise<chrome.devtools.network.HARLog> => {
+  const chrome = chromeProvider();
+  return new Promise((resolve) => {
+    chrome.devtools.network.getHAR((harLog) => {
+      resolve(harLog);
+    });
+  });
+};
+
 export const onRequestFinished = (
   cb: (e: chrome.devtools.network.Request) => void
 ) => {
   const chrome = chromeProvider();
+
   chrome.devtools.network.onRequestFinished.addListener(cb);
   return () => {
     chrome.devtools.network.onRequestFinished.removeListener(cb);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1817,10 +1817,10 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/chrome@^0.0.122":
-  version "0.0.122"
-  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.122.tgz#65265d3854f511c2c1e779148e97982ee00b460f"
-  integrity sha512-xHmT1AlBwKAVpQmv+/5gUsB1FXLUiizIZI6bIM52DJDtEhv97FkryHkohjw2HZqAGLOxuJ3kae7YfgWIZ+hMrg==
+"@types/chrome@^0.0.154":
+  version "0.0.154"
+  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.154.tgz#7992e97364f4447e961028ad07ac843d0b052c2d"
+  integrity sha512-6QmP744MeMUZUIUHED4d4L2la5dIF1e6bcrkGF4yGQTyO94ER+r++Ss165wkzA5cAGUYt8kToDa6L9xtNqVMxg==
   dependencies:
     "@types/filesystem" "*"
     "@types/har-format" "*"


### PR DESCRIPTION
If requests come in before the app is running they will not be recorded. This means users need to refresh to refetch those requests.

To resolve this we can get previous historic HAR logs for the given session and load them into the app at startup. This uses the chrome API `chrome.devtools.network.getHAR`