### PR TITLE
Keyboard navigation

### DIFF
--- a/src/containers/Main/index.tsx
+++ b/src/containers/Main/index.tsx
@@ -9,6 +9,7 @@ import {
   NetworkRequest,
 } from "../../hooks/useNetworkMonitor";
 import { onNavigate } from "../../services/networkMonitor";
+import { useKeyPress } from "../../hooks/useKeyPress";
 
 const filterNetworkRequests = (
   networkRequests: NetworkRequest[],
@@ -28,14 +29,14 @@ export const Main = () => {
   const [selectedRowId, setSelectedRowId] = useState<string | number | null>(
     null
   );
-  const [selectedRequest, setSelectedRequest] = useState<NetworkRequest | null>(
-    null
-  );
   const [searchValue, setSearchValue] = useState("");
   const [isPreserveLogs, setIsPreserveLogs] = useState(false);
   const filteredNetworkRequests = filterNetworkRequests(
     networkRequests,
     searchValue
+  );
+  const selectedRequest = networkRequests.find(
+    (request) => request.id === selectedRowId
   );
 
   useEffect(() => {
@@ -59,13 +60,10 @@ export const Main = () => {
     <NetworkTable
       data={filteredNetworkRequests}
       selectedRowId={selectedRowId}
-      onRowClick={(rowId, data) => {
-        setSelectedRequest(data);
-        setSelectedRowId(rowId);
-      }}
+      onRowClick={setSelectedRowId}
+      onRowSelect={setSelectedRowId}
       showSingleColumn={Boolean(selectedRequest)}
       onClear={() => {
-        setSelectedRequest(null);
         setSelectedRowId(null);
         clearWebRequests();
       }}
@@ -93,7 +91,6 @@ export const Main = () => {
                 data={selectedRequest}
                 onClose={() => {
                   setSelectedRowId(null);
-                  setSelectedRequest(null);
                 }}
               />
             </div>

--- a/src/containers/NetworkTable/index.test.tsx
+++ b/src/containers/NetworkTable/index.test.tsx
@@ -1,1 +1,106 @@
-// TODO add tests for keyboard navigation
+import React from "react";
+import { NetworkTable } from "./index";
+import { render, fireEvent } from "@testing-library/react";
+
+const request = {
+  time: 1000,
+  status: 200,
+  url: "https://someurl.com/graphql",
+  request: {
+    primaryOperation: {
+      operation: "",
+      operationName: "",
+    },
+    body: [],
+  },
+  response: {
+    bodySize: 1000,
+  },
+};
+
+const data = [
+  {
+    id: "1",
+    ...request,
+  },
+  {
+    id: "2",
+    ...request,
+  },
+  {
+    id: "3",
+    ...request,
+  },
+] as any[];
+
+test("Selects next row when pressing the down arrow", () => {
+  const mockOnRowSelect = jest.fn();
+  const { getByTestId } = render(
+    <NetworkTable
+      data={data}
+      onRowClick={() => {}}
+      onRowSelect={mockOnRowSelect}
+      onClear={() => {}}
+      selectedRowId="2"
+    />
+  );
+  const table = getByTestId("network-table");
+
+  fireEvent.keyDown(table, { code: "ArrowDown" });
+
+  expect(mockOnRowSelect).toHaveBeenCalledWith("3");
+});
+
+test("Selects previous row when pressing the up arrow", () => {
+  const mockOnRowSelect = jest.fn();
+  const { getByTestId } = render(
+    <NetworkTable
+      data={data}
+      onRowClick={() => {}}
+      onRowSelect={mockOnRowSelect}
+      onClear={() => {}}
+      selectedRowId="2"
+    />
+  );
+  const table = getByTestId("network-table");
+
+  fireEvent.keyDown(table, { code: "ArrowUp" });
+
+  expect(mockOnRowSelect).toHaveBeenCalledWith("1");
+});
+
+test("Remains on bottom row when pressing the down arrow", () => {
+  const mockOnRowSelect = jest.fn();
+  const { getByTestId } = render(
+    <NetworkTable
+      data={data}
+      onRowClick={() => {}}
+      onRowSelect={mockOnRowSelect}
+      onClear={() => {}}
+      selectedRowId="3"
+    />
+  );
+  const table = getByTestId("network-table");
+
+  fireEvent.keyDown(table, { code: "ArrowDown" });
+
+  expect(mockOnRowSelect).not.toHaveBeenCalled();
+});
+
+test("Remains on top row when pressing the up arrow", () => {
+  const mockOnRowSelect = jest.fn();
+  const { getByTestId } = render(
+    <NetworkTable
+      data={data}
+      onRowClick={() => {}}
+      onRowSelect={mockOnRowSelect}
+      onClear={() => {}}
+      selectedRowId="1"
+    />
+  );
+  const table = getByTestId("network-table");
+
+  fireEvent.keyDown(table, { code: "ArrowUp" });
+
+  expect(mockOnRowSelect).not.toHaveBeenCalled();
+});

--- a/src/containers/NetworkTable/index.test.tsx
+++ b/src/containers/NetworkTable/index.test.tsx
@@ -1,0 +1,1 @@
+// TODO add tests for keyboard navigation

--- a/src/containers/NetworkTable/index.tsx
+++ b/src/containers/NetworkTable/index.tsx
@@ -14,7 +14,7 @@ export type NetworkTableProps = {
   onRowSelect: (rowId: string | number) => void;
   onClear: () => void;
   selectedRowId?: string | number | null;
-  showSingleColumn: boolean;
+  showSingleColumn?: boolean;
 };
 
 const ClearButton = ({ onClick }: { onClick: () => void }) => (

--- a/src/containers/NetworkTable/index.tsx
+++ b/src/containers/NetworkTable/index.tsx
@@ -6,10 +6,12 @@ import { BinIcon } from "../../components/Icons/BinIcon";
 import { Badge } from "../../components/Badge";
 import { getStatusColor } from "../../helpers/getStatusColor";
 import { NetworkRequest } from "../../hooks/useNetworkMonitor";
+import { useKeyPress } from "../../hooks/useKeyPress";
 
 export type NetworkTableProps = {
   data: NetworkRequest[];
   onRowClick: (rowId: string | number, row: NetworkRequest) => void;
+  onRowSelect: (rowId: string | number) => void;
   onClear: () => void;
   selectedRowId?: string | number | null;
   showSingleColumn: boolean;
@@ -76,7 +78,31 @@ const Time = ({ ms }: { ms: number }) => {
 };
 
 export const NetworkTable = (props: NetworkTableProps) => {
-  const { data, onRowClick, onClear, selectedRowId, showSingleColumn } = props;
+  const {
+    data,
+    onRowClick,
+    onRowSelect,
+    onClear,
+    selectedRowId,
+    showSingleColumn,
+  } = props;
+
+  const selectNextRow = (direction: "up" | "down") => {
+    const directionCount = direction === "up" ? -1 : 1;
+    const selectedRowIndex = data.findIndex((row) => row.id === selectedRowId);
+    const nextRow = data[selectedRowIndex + directionCount];
+    if (nextRow) {
+      onRowSelect(nextRow.id);
+    }
+  };
+
+  useKeyPress("ArrowUp", () => {
+    selectNextRow("up");
+  });
+
+  useKeyPress("ArrowDown", () => {
+    selectNextRow("down");
+  });
 
   const columns = useMemo(() => {
     const columns = [

--- a/src/hooks/useKeyPress.ts
+++ b/src/hooks/useKeyPress.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+type Code = "ArrowDown" | "ArrowUp";
+
+export const useKeyPress = (code: Code, cb: () => void) => {
+  useEffect(() => {
+    const handleKeyPress = (event: KeyboardEvent) => {
+      if (event.code === code) {
+        cb();
+      }
+    };
+    window.addEventListener("keydown", handleKeyPress);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyPress);
+    };
+  }, [code, cb]);
+};


### PR DESCRIPTION
Add keyboard navigation through up and down arrows to navigate the main request table. This improved accessibility and is generally a better UX.

The main functionality runs through the new hook useKeyPress