### PR TITLE
Prefer operation name over field name

### DIFF
--- a/src/helpers/graphqlHelpers.test.ts
+++ b/src/helpers/graphqlHelpers.test.ts
@@ -6,7 +6,7 @@ describe("GraphQL Helpers", () => {
       JSON.stringify([
         {
           query: `
-            query searchMovie($title: String) {
+            query searchMovieQuery($title: String) {
               searchMovie(title: $title) {
                 id
                 title
@@ -22,7 +22,7 @@ describe("GraphQL Helpers", () => {
     );
 
     expect(operation).toEqual({
-      operationName: "searchMovie",
+      operationName: "searchMovieQuery",
       operation: "query",
     });
   });
@@ -32,7 +32,7 @@ describe("GraphQL Helpers", () => {
       JSON.stringify([
         {
           query: `
-            mutation createMovie($title: String, $genre: String) {
+            mutation createMovieMutation($title: String, $genre: String) {
               createMovie(title: $title, genre: $genre) {
                 id
                 title
@@ -48,7 +48,7 @@ describe("GraphQL Helpers", () => {
     );
 
     expect(operation).toEqual({
-      operationName: "createMovie",
+      operationName: "createMovieMutation",
       operation: "mutation",
     });
   });
@@ -63,7 +63,7 @@ describe("GraphQL Helpers", () => {
               lastName
             }
 
-            query getMovie($title: String) {
+            query getMovieQuery($title: String) {
               getMovie(title: $title) {
                 id
                 title
@@ -79,7 +79,7 @@ describe("GraphQL Helpers", () => {
     );
 
     expect(operation).toEqual({
-      operationName: "getMovie",
+      operationName: "getMovieQuery",
       operation: "query",
     });
   });

--- a/src/helpers/graphqlHelpers.ts
+++ b/src/helpers/graphqlHelpers.ts
@@ -36,7 +36,7 @@ export const getPrimaryOperation = (
       (selection) => selection.kind === "Field"
     ) as FieldNode;
     const operationName =
-      field?.name.value || firstOperationDefinition.name?.value;
+      firstOperationDefinition.name?.value || field?.name.value;
 
     if (!operationName) {
       throw new Error("Operation name could not be determined");

--- a/src/mocks/mock-requests.ts
+++ b/src/mocks/mock-requests.ts
@@ -74,7 +74,7 @@ export const mockRequests = [
             lastName
           }
 
-          query getMovie($title: String) {
+          query getMovieQuery($title: String) {
             getMovie(title: $title) {
               id
               title
@@ -101,7 +101,7 @@ export const mockRequests = [
     request: [
       {
         query: `
-          query searchMovie($title: String) {
+          query searchMovieQuery($title: String) {
             searchMovie(title: $title) {
               id
               title
@@ -140,7 +140,7 @@ export const mockRequests = [
     request: [
       {
         query: `
-          mutation createMovie($title: String, $genre: String) {
+          mutation createMovieMutation($title: String, $genre: String) {
             createMovie(title: $title, genre: $genre) {
               id
               title
@@ -167,7 +167,7 @@ export const mockRequests = [
     request: [
       {
         query: `
-          query listActors {
+          query {
             listActors {
               id
               name
@@ -178,7 +178,7 @@ export const mockRequests = [
       },
       {
         query: `
-          query listCategories {
+          query {
             listCategories {
               id
               title
@@ -221,7 +221,7 @@ export const mockRequests = [
     request: [
       {
         query: `
-          query actorDetails($id: String) {
+          query actorDetailsQuery($id: String) {
             actorDetails(id: $id) {
               ...actorDetailsData
               __typename


### PR DESCRIPTION
This updates the logic for determining the operation name displayed in the left column to prefer the API-consumer-provided operation name over the top-level field name. It will still fall back to the top-level field name when no operation name is provided. The use-case here is that, in practice, GraphQL types are often organized into a tree structure where the top-level field is not very descriptive as to what is actually being queried (e.g., the top level field may be something like `organization` for every query). For mutations, the consumer-provided name will generally be either more descriptive or the same as the mutation field name. In any case, the users of this extension are likely developers that defined the operation names and would be more interested in seeing those names.

![Screen Shot 2021-08-10 at 1 56 13 PM](https://user-images.githubusercontent.com/348630/128910809-d91c05cf-c619-4775-a3b0-f6074933cb86.png)

![Screen Shot 2021-08-10 at 1 56 29 PM](https://user-images.githubusercontent.com/348630/128910834-9c05cd3e-8409-47dc-82eb-675ab7db32a8.png)

![Screen Shot 2021-08-10 at 1 56 44 PM](https://user-images.githubusercontent.com/348630/128910856-d40f3ee6-19e2-4ed6-8438-c5a9f1bde792.png)