### PR TITLE
Added wildcard instead relative paths

### DIFF
--- a/src/containers/App/index.tsx
+++ b/src/containers/App/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { SearchProvider } from "@hooks/useSearch";
-import { NetworkTabsProvider } from "@hooks/useNetworkTabs";
-import { useDarkTheme } from "@hooks/useTheme";
+import { SearchProvider } from "hooks/useSearch";
+import { NetworkTabsProvider } from "hooks/useNetworkTabs";
+import { useDarkTheme } from "hooks/useTheme";
 import { Main } from "../Main";
 
 export const App = () => {

--- a/src/containers/App/index.tsx
+++ b/src/containers/App/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { SearchProvider } from "../../hooks/useSearch";
-import { NetworkTabsProvider } from "../../hooks/useNetworkTabs";
-import { useDarkTheme } from "../../hooks/useTheme";
+import { SearchProvider } from "@hooks/useSearch";
+import { NetworkTabsProvider } from "@hooks/useNetworkTabs";
+import { useDarkTheme } from "@hooks/useTheme";
 import { Main } from "../Main";
 
 export const App = () => {

--- a/src/containers/Main/Main.test.tsx
+++ b/src/containers/Main/Main.test.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { render, fireEvent, within, waitFor } from "@testing-library/react";
 import { Main } from "./index";
-import { chromeProvider } from "@services/chromeProvider";
-import { mockChrome } from "@mocks/mock-chrome";
+import { chromeProvider } from "services/chromeProvider";
+import { mockChrome } from "mocks/mock-chrome";
 import { act } from "react-dom/test-utils";
 
-jest.mock("@services/chromeProvider");
+jest.mock("services/chromeProvider");
 
 const mockChromeProvider = chromeProvider as jest.Mock;
 

--- a/src/containers/Main/Main.test.tsx
+++ b/src/containers/Main/Main.test.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { render, fireEvent, within, waitFor } from "@testing-library/react";
 import { Main } from "./index";
-import { chromeProvider } from "../../services/chromeProvider";
-import { mockChrome } from "../../mocks/mock-chrome";
+import { chromeProvider } from "@services/chromeProvider";
+import { mockChrome } from "@mocks/mock-chrome";
 import { act } from "react-dom/test-utils";
 
-jest.mock("../../services/chromeProvider");
+jest.mock("@services/chromeProvider");
 
 const mockChromeProvider = chromeProvider as jest.Mock;
 

--- a/src/containers/Main/index.tsx
+++ b/src/containers/Main/index.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
-import { SplitPaneLayout } from "../../components/Layout";
-import { useNetworkMonitor } from "../../hooks/useNetworkMonitor";
-import { useSearch } from "../../hooks/useSearch";
-import { useNetworkTabs } from "../../hooks/useNetworkTabs";
+import { SplitPaneLayout } from "@components/Layout";
+import { useNetworkMonitor } from "@hooks/useNetworkMonitor";
+import { useSearch } from "@hooks/useSearch";
+import { useNetworkTabs } from "@hooks/useNetworkTabs";
 import { NetworkPanel } from "../NetworkPanel";
 import { SearchPanel } from "../SearchPanel";
 

--- a/src/containers/Main/index.tsx
+++ b/src/containers/Main/index.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
-import { SplitPaneLayout } from "@components/Layout";
-import { useNetworkMonitor } from "@hooks/useNetworkMonitor";
-import { useSearch } from "@hooks/useSearch";
-import { useNetworkTabs } from "@hooks/useNetworkTabs";
+import { SplitPaneLayout } from "components/Layout";
+import { useNetworkMonitor } from "hooks/useNetworkMonitor";
+import { useSearch } from "hooks/useSearch";
+import { useNetworkTabs } from "hooks/useNetworkTabs";
 import { NetworkPanel } from "../NetworkPanel";
 import { SearchPanel } from "../SearchPanel";
 

--- a/src/containers/NetworkPanel/NetworkDetails/HeaderView/HeaderList.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/HeaderView/HeaderList.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Header } from "../../../../hooks/useNetworkMonitor";
+import { Header } from "@hooks/useNetworkMonitor";
 
 interface IHeadersProps {
   headers: Header[];

--- a/src/containers/NetworkPanel/NetworkDetails/HeaderView/HeaderList.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/HeaderView/HeaderList.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Header } from "@hooks/useNetworkMonitor";
+import { Header } from "hooks/useNetworkMonitor";
 
 interface IHeadersProps {
   headers: Header[];

--- a/src/containers/NetworkPanel/NetworkDetails/HeaderView/index.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/HeaderView/index.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
-import { Header } from "@hooks/useNetworkMonitor";
+import { Header } from "hooks/useNetworkMonitor";
 import { Panels, PanelSection } from "../PanelSection";
-import { CopyButton } from "@components/CopyButton";
+import { CopyButton } from "components/CopyButton";
 import { HeaderList } from "./HeaderList";
 
 interface IHeaderViewProps {

--- a/src/containers/NetworkPanel/NetworkDetails/HeaderView/index.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/HeaderView/index.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
-import { Header } from "../../../../hooks/useNetworkMonitor";
+import { Header } from "@hooks/useNetworkMonitor";
 import { Panels, PanelSection } from "../PanelSection";
-import { CopyButton } from "../../../../components/CopyButton";
+import { CopyButton } from "@components/CopyButton";
 import { HeaderList } from "./HeaderList";
 
 interface IHeaderViewProps {

--- a/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { Panels, PanelSection } from "./PanelSection";
-import { CodeBlock } from "../../../components/CodeBlock";
-import { CopyButton } from "../../../components/CopyButton";
-import * as safeJson from "../../../helpers/safeJson";
+import { CodeBlock } from "@components/CodeBlock";
+import { CopyButton } from "@components/CopyButton";
+import * as safeJson from "@helpers/safeJson";
 
 interface IRequestViewProps {
   requests: {

--- a/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { Panels, PanelSection } from "./PanelSection";
-import { CodeBlock } from "@components/CodeBlock";
-import { CopyButton } from "@components/CopyButton";
-import * as safeJson from "@helpers/safeJson";
+import { CodeBlock } from "components/CodeBlock";
+import { CopyButton } from "components/CopyButton";
+import * as safeJson from "helpers/safeJson";
 
 interface IRequestViewProps {
   requests: {

--- a/src/containers/NetworkPanel/NetworkDetails/ResponseRawView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/ResponseRawView.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
-import * as safeJson from "@helpers/safeJson";
-import { CodeBlock } from "@components/CodeBlock";
-import { CopyButton } from "@components/CopyButton";
+import * as safeJson from "helpers/safeJson";
+import { CodeBlock } from "components/CodeBlock";
+import { CopyButton } from "components/CopyButton";
 
 interface IResponseRawViewProps {
   response?: string;

--- a/src/containers/NetworkPanel/NetworkDetails/ResponseRawView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/ResponseRawView.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
-import * as safeJson from "../../../helpers/safeJson";
-import { CodeBlock } from "../../../components/CodeBlock";
-import { CopyButton } from "../../../components/CopyButton";
+import * as safeJson from "@helpers/safeJson";
+import { CodeBlock } from "@components/CodeBlock";
+import { CopyButton } from "@components/CopyButton";
 
 interface IResponseRawViewProps {
   response?: string;

--- a/src/containers/NetworkPanel/NetworkDetails/ResponseView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/ResponseView.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
-import * as safeJson from "../../../helpers/safeJson";
-import { JsonView } from "../../../components/JsonView";
-import { CopyButton } from "../../../components/CopyButton";
+import * as safeJson from "@helpers/safeJson";
+import { JsonView } from "@components/JsonView";
+import { CopyButton } from "@components/CopyButton";
 
 interface IResponseViewProps {
   response?: string;

--- a/src/containers/NetworkPanel/NetworkDetails/ResponseView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/ResponseView.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
-import * as safeJson from "@helpers/safeJson";
-import { JsonView } from "@components/JsonView";
-import { CopyButton } from "@components/CopyButton";
+import * as safeJson from "helpers/safeJson";
+import { JsonView } from "components/JsonView";
+import { CopyButton } from "components/CopyButton";
 
 interface IResponseViewProps {
   response?: string;

--- a/src/containers/NetworkPanel/NetworkDetails/index.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/index.tsx
@@ -1,12 +1,12 @@
 import React from "react";
-import { Tabs } from "@components/Tabs";
-import { NetworkRequest } from "@hooks/useNetworkMonitor";
+import { Tabs } from "components/Tabs";
+import { NetworkRequest } from "hooks/useNetworkMonitor";
 import { HeaderView } from "./HeaderView";
 import { RequestView } from "./RequestView";
 import { ResponseView } from "./ResponseView";
 import { ResponseRawView } from "./ResponseRawView";
-import { useNetworkTabs } from "@hooks/useNetworkTabs";
-import { CloseButton } from "@components/CloseButton";
+import { useNetworkTabs } from "hooks/useNetworkTabs";
+import { CloseButton } from "components/CloseButton";
 
 export type NetworkDetailsProps = {
   data: NetworkRequest;

--- a/src/containers/NetworkPanel/NetworkDetails/index.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/index.tsx
@@ -1,12 +1,12 @@
 import React from "react";
-import { Tabs } from "../../../components/Tabs";
-import { NetworkRequest } from "../../../hooks/useNetworkMonitor";
+import { Tabs } from "@components/Tabs";
+import { NetworkRequest } from "@hooks/useNetworkMonitor";
 import { HeaderView } from "./HeaderView";
 import { RequestView } from "./RequestView";
 import { ResponseView } from "./ResponseView";
 import { ResponseRawView } from "./ResponseRawView";
-import { useNetworkTabs } from "../../../hooks/useNetworkTabs";
-import { CloseButton } from "../../../components/CloseButton";
+import { useNetworkTabs } from "@hooks/useNetworkTabs";
+import { CloseButton } from "@components/CloseButton";
 
 export type NetworkDetailsProps = {
   data: NetworkRequest;

--- a/src/containers/NetworkPanel/NetworkTable/index.tsx
+++ b/src/containers/NetworkPanel/NetworkTable/index.tsx
@@ -1,15 +1,15 @@
 import React, { useMemo } from "react";
 import prettyBytes from "pretty-bytes";
 import prettyMs from "pretty-ms";
-import { Table, TableProps } from "../../../components/Table";
-import { BinIcon } from "../../../components/Icons/BinIcon";
-import { Dot } from "../../../components/Dot";
-import { Badge } from "../../../components/Badge";
-import { getStatusColor } from "../../../helpers/getStatusColor";
-import { NetworkRequest } from "../../../hooks/useNetworkMonitor";
-import { useKeyDown } from "../../../hooks/useKeyDown";
-import { getErrorMessages } from "../../../helpers/graphqlHelpers";
-import { IconButton } from "../../../components/IconButton";
+import { Table, TableProps } from "@components/Table";
+import { BinIcon } from "@components/Icons/BinIcon";
+import { Dot } from "@components/Dot";
+import { Badge } from "@components/Badge";
+import { getStatusColor } from "@helpers/getStatusColor";
+import { NetworkRequest } from "@hooks/useNetworkMonitor";
+import { useKeyDown } from "@hooks/useKeyDown";
+import { getErrorMessages } from "@helpers/graphqlHelpers";
+import { IconButton } from "@components/IconButton";
 
 export type NetworkTableProps = {
   data: NetworkRequest[];

--- a/src/containers/NetworkPanel/NetworkTable/index.tsx
+++ b/src/containers/NetworkPanel/NetworkTable/index.tsx
@@ -1,15 +1,15 @@
 import React, { useMemo } from "react";
 import prettyBytes from "pretty-bytes";
 import prettyMs from "pretty-ms";
-import { Table, TableProps } from "@components/Table";
-import { BinIcon } from "@components/Icons/BinIcon";
-import { Dot } from "@components/Dot";
-import { Badge } from "@components/Badge";
-import { getStatusColor } from "@helpers/getStatusColor";
-import { NetworkRequest } from "@hooks/useNetworkMonitor";
-import { useKeyDown } from "@hooks/useKeyDown";
-import { getErrorMessages } from "@helpers/graphqlHelpers";
-import { IconButton } from "@components/IconButton";
+import { Table, TableProps } from "components/Table";
+import { BinIcon } from "components/Icons/BinIcon";
+import { Dot } from "components/Dot";
+import { Badge } from "components/Badge";
+import { getStatusColor } from "helpers/getStatusColor";
+import { NetworkRequest } from "hooks/useNetworkMonitor";
+import { useKeyDown } from "hooks/useKeyDown";
+import { getErrorMessages } from "helpers/graphqlHelpers";
+import { IconButton } from "components/IconButton";
 
 export type NetworkTableProps = {
   data: NetworkRequest[];

--- a/src/containers/NetworkPanel/index.tsx
+++ b/src/containers/NetworkPanel/index.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from "react";
-import { SplitPaneLayout } from "@components/Layout";
+import { SplitPaneLayout } from "components/Layout";
 import { NetworkTable } from "./NetworkTable";
 import { NetworkDetails } from "./NetworkDetails";
 import { Toolbar } from "../Toolbar";
-import { NetworkRequest } from "@hooks/useNetworkMonitor";
-import { onNavigate } from "@services/networkMonitor";
+import { NetworkRequest } from "hooks/useNetworkMonitor";
+import { onNavigate } from "services/networkMonitor";
 
 interface NetworkPanelProps {
   selectedRowId: string | number | null;

--- a/src/containers/NetworkPanel/index.tsx
+++ b/src/containers/NetworkPanel/index.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from "react";
-import { SplitPaneLayout } from "../../components/Layout";
+import { SplitPaneLayout } from "@components/Layout";
 import { NetworkTable } from "./NetworkTable";
 import { NetworkDetails } from "./NetworkDetails";
 import { Toolbar } from "../Toolbar";
-import { NetworkRequest } from "../../hooks/useNetworkMonitor";
-import { onNavigate } from "../../services/networkMonitor";
+import { NetworkRequest } from "@hooks/useNetworkMonitor";
+import { onNavigate } from "@services/networkMonitor";
 
 interface NetworkPanelProps {
   selectedRowId: string | number | null;

--- a/src/containers/SearchPanel/SearchResults.tsx
+++ b/src/containers/SearchPanel/SearchResults.tsx
@@ -1,12 +1,12 @@
 import React from "react";
-import { HighlightedText } from "@components/HighlightedText";
-import { ISearchResult } from "@services/searchService";
+import { HighlightedText } from "components/HighlightedText";
+import { ISearchResult } from "services/searchService";
 import {
   getHeaderSearchContent,
   getRequestSearchContent,
   getResponseSearchContent,
-} from "@helpers/getSearchContent";
-import { NetworkTabs } from "@hooks/useNetworkTabs";
+} from "helpers/getSearchContent";
+import { NetworkTabs } from "hooks/useNetworkTabs";
 
 interface ISearchResultsProps {
   searchQuery: string;

--- a/src/containers/SearchPanel/SearchResults.tsx
+++ b/src/containers/SearchPanel/SearchResults.tsx
@@ -1,12 +1,12 @@
 import React from "react";
-import { HighlightedText } from "../../components/HighlightedText";
-import { ISearchResult } from "../../services/searchService";
+import { HighlightedText } from "@components/HighlightedText";
+import { ISearchResult } from "@services/searchService";
 import {
   getHeaderSearchContent,
   getRequestSearchContent,
   getResponseSearchContent,
-} from "../../helpers/getSearchContent";
-import { NetworkTabs } from "../../hooks/useNetworkTabs";
+} from "@helpers/getSearchContent";
+import { NetworkTabs } from "@hooks/useNetworkTabs";
 
 interface ISearchResultsProps {
   searchQuery: string;

--- a/src/containers/SearchPanel/index.tsx
+++ b/src/containers/SearchPanel/index.tsx
@@ -1,13 +1,13 @@
 import React, { useMemo, useState } from "react";
-import { Textfield } from "@components/Textfield";
-import { useKeyDown } from "@hooks/useKeyDown";
-import { NetworkRequest } from "@hooks/useNetworkMonitor";
-import { useSearch } from "@hooks/useSearch";
-import { NetworkTabs } from "@hooks/useNetworkTabs";
-import { getSearchResults, ISearchResult } from "@services/searchService";
+import { Textfield } from "components/Textfield";
+import { useKeyDown } from "hooks/useKeyDown";
+import { NetworkRequest } from "hooks/useNetworkMonitor";
+import { useSearch } from "hooks/useSearch";
+import { NetworkTabs } from "hooks/useNetworkTabs";
+import { getSearchResults, ISearchResult } from "services/searchService";
 import { SearchResults } from "./SearchResults";
-import { Header } from "@components/Header";
-import { CloseButton } from "@components/CloseButton";
+import { Header } from "components/Header";
+import { CloseButton } from "components/CloseButton";
 
 interface ISearchPanelProps {
   networkRequests: NetworkRequest[];

--- a/src/containers/SearchPanel/index.tsx
+++ b/src/containers/SearchPanel/index.tsx
@@ -1,13 +1,13 @@
 import React, { useMemo, useState } from "react";
-import { Textfield } from "../../components/Textfield";
-import { useKeyDown } from "../../hooks/useKeyDown";
-import { NetworkRequest } from "../../hooks/useNetworkMonitor";
-import { useSearch } from "../../hooks/useSearch";
-import { NetworkTabs } from "../../hooks/useNetworkTabs";
-import { getSearchResults, ISearchResult } from "../../services/searchService";
+import { Textfield } from "@components/Textfield";
+import { useKeyDown } from "@hooks/useKeyDown";
+import { NetworkRequest } from "@hooks/useNetworkMonitor";
+import { useSearch } from "@hooks/useSearch";
+import { NetworkTabs } from "@hooks/useNetworkTabs";
+import { getSearchResults, ISearchResult } from "@services/searchService";
 import { SearchResults } from "./SearchResults";
-import { Header } from "../../components/Header";
-import { CloseButton } from "../../components/CloseButton";
+import { Header } from "@components/Header";
+import { CloseButton } from "@components/CloseButton";
 
 interface ISearchPanelProps {
   networkRequests: NetworkRequest[];

--- a/src/containers/Toolbar/index.tsx
+++ b/src/containers/Toolbar/index.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { Checkbox } from "../../components/Checkbox";
-import { IconButton } from "../../components/IconButton";
-import { SearchIcon } from "../../components/Icons/SearchIcon";
-import { Textfield } from "../../components/Textfield";
-import { useSearch } from "../../hooks/useSearch";
+import { Checkbox } from "@components/Checkbox";
+import { IconButton } from "@components/IconButton";
+import { SearchIcon } from "@components/Icons/SearchIcon";
+import { Textfield } from "@components/Textfield";
+import { useSearch } from "@hooks/useSearch";
 
 interface IToolbarProps {
   filterValue: string;

--- a/src/containers/Toolbar/index.tsx
+++ b/src/containers/Toolbar/index.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { Checkbox } from "@components/Checkbox";
-import { IconButton } from "@components/IconButton";
-import { SearchIcon } from "@components/Icons/SearchIcon";
-import { Textfield } from "@components/Textfield";
-import { useSearch } from "@hooks/useSearch";
+import { Checkbox } from "components/Checkbox";
+import { IconButton } from "components/IconButton";
+import { SearchIcon } from "components/Icons/SearchIcon";
+import { Textfield } from "components/Textfield";
+import { useSearch } from "hooks/useSearch";
 
 interface IToolbarProps {
   filterValue: string;

--- a/src/helpers/getSearchContent.ts
+++ b/src/helpers/getSearchContent.ts
@@ -1,5 +1,5 @@
 import { stringify } from "./safeJson";
-import { Header, NetworkRequest } from "@hooks/useNetworkMonitor";
+import { Header, NetworkRequest } from "hooks/useNetworkMonitor";
 
 const stringifyHeaders = (headers: Header[] = []) => {
   return headers

--- a/src/helpers/getSearchContent.ts
+++ b/src/helpers/getSearchContent.ts
@@ -1,5 +1,5 @@
 import { stringify } from "./safeJson";
-import { Header, NetworkRequest } from "../hooks/useNetworkMonitor";
+import { Header, NetworkRequest } from "@hooks/useNetworkMonitor";
 
 const stringifyHeaders = (headers: Header[] = []) => {
   return headers

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,4 +1,4 @@
-import { chromeProvider } from "../services/chromeProvider";
+import { chromeProvider } from "@services/chromeProvider";
 
 export const useDarkTheme = () => {
   const chrome = chromeProvider();

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,4 +1,4 @@
-import { chromeProvider } from "@services/chromeProvider";
+import { chromeProvider } from "services/chromeProvider";
 
 export const useDarkTheme = () => {
   const chrome = chromeProvider();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import { App } from "@containers/App";
+import { App } from "containers/App";
 import "./index.css";
 
 ReactDOM.render(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import { App } from "./containers/App";
+import { App } from "@containers/App";
 import "./index.css";
 
 ReactDOM.render(

--- a/src/mocks/mock-chrome.ts
+++ b/src/mocks/mock-chrome.ts
@@ -1,4 +1,4 @@
-import { mockRequests } from "@mocks/mock-requests";
+import { mockRequests } from "mocks/mock-requests";
 
 let removeListeners: Record<string, () => void> = {};
 

--- a/src/mocks/mock-chrome.ts
+++ b/src/mocks/mock-chrome.ts
@@ -1,4 +1,4 @@
-import { mockRequests } from "../mocks/mock-requests";
+import { mockRequests } from "@mocks/mock-requests";
 
 let removeListeners: Record<string, () => void> = {};
 
@@ -30,8 +30,8 @@ export const mockChrome = {
         },
       },
       onNavigated: {
-        addListener: (cb) => {},
-        removeListener: (cb) => {},
+        addListener: (cb) => { },
+        removeListener: (cb) => { },
       },
     },
   },

--- a/src/services/chromeProvider.ts
+++ b/src/services/chromeProvider.ts
@@ -1,4 +1,4 @@
-import { mockChrome } from "../mocks/mock-chrome";
+import { mockChrome } from "@mocks/mock-chrome";
 
 export const chromeProvider = (): typeof chrome => {
   return typeof chrome === "undefined" || !chrome?.devtools

--- a/src/services/chromeProvider.ts
+++ b/src/services/chromeProvider.ts
@@ -1,4 +1,4 @@
-import { mockChrome } from "@mocks/mock-chrome";
+import { mockChrome } from "mocks/mock-chrome";
 
 export const chromeProvider = (): typeof chrome => {
   return typeof chrome === "undefined" || !chrome?.devtools

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -2,8 +2,8 @@ import {
   getHeaderSearchContent,
   getRequestSearchContent,
   getResponseSearchContent,
-} from "@helpers/getSearchContent";
-import { NetworkRequest } from "@hooks/useNetworkMonitor";
+} from "helpers/getSearchContent";
+import { NetworkRequest } from "hooks/useNetworkMonitor";
 
 export interface ISearchResult {
   matches: {

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -2,8 +2,8 @@ import {
   getHeaderSearchContent,
   getRequestSearchContent,
   getResponseSearchContent,
-} from "../helpers/getSearchContent";
-import { NetworkRequest } from "../hooks/useNetworkMonitor";
+} from "@helpers/getSearchContent";
+import { NetworkRequest } from "@hooks/useNetworkMonitor";
 
 export interface ISearchResult {
   matches: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "target": "es5",
     "lib": [
       "dom",
@@ -18,7 +19,15 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react",
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "@components/*": ["./src/components/*"],
+      "@containers/*": ["./src/containers/*"],
+      "@helpers/*": ["./src/helpers/*"],
+      "@hooks/*": ["./src/hooks/*"],
+      "@mocks/*": ["./src/mocks/*"],
+      "@services/*": ["./src/services/*"],
+    }
   },
   "include": [
     "src",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
+    "baseUrl": "src",
     "target": "es5",
     "lib": [
       "dom",
@@ -20,14 +20,6 @@
     "noEmit": true,
     "jsx": "react",
     "noFallthroughCasesInSwitch": true,
-    "paths": {
-      "@components/*": ["./src/components/*"],
-      "@containers/*": ["./src/containers/*"],
-      "@helpers/*": ["./src/helpers/*"],
-      "@hooks/*": ["./src/hooks/*"],
-      "@mocks/*": ["./src/mocks/*"],
-      "@services/*": ["./src/services/*"],
-    }
   },
   "include": [
     "src",


### PR DESCRIPTION
I was thinking that it would be much easier if we change the `basePath` to src so we don't have to rewrite every time the relative paths 🤔 

I tried adding the `@` wildcard but for now CRA seems overriding it, the only (clean) thing we can do as of today is this with the `basePath` rule in **tsconfig.json**

How do you think about this?