### PR TITLE
Bug handle missing variables in query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-app",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "private": true,
   "dependencies": {
     "classnames": "^2.3.1",

--- a/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
@@ -3,20 +3,22 @@ import { Panels, PanelSection } from "./PanelSection";
 import { CodeBlock } from "../../../components/CodeBlock";
 import { CopyButton } from "../../../components/CopyButton";
 import * as safeJson from "../../../helpers/safeJson";
+import { IGraphqlRequestBody } from "../../../helpers/graphqlHelpers";
 
 interface IRequestViewProps {
-  requests: {
-    query: string;
-    variables: object;
-  }[];
+  requests: IGraphqlRequestBody[];
 }
+
+const isVariablesPopulated = (request: IGraphqlRequestBody) => {
+  return Object.keys(request.variables || {}).length > 0;
+};
 
 export const RequestView = (props: IRequestViewProps) => {
   const { requests } = props;
 
   return (
     <Panels>
-      {requests.map((request, i) => {
+      {requests.map((request) => {
         return (
           <PanelSection key={request.query} className="relative">
             <CopyButton
@@ -24,7 +26,7 @@ export const RequestView = (props: IRequestViewProps) => {
               className="absolute right-6 top-6 z-10"
             />
             <CodeBlock text={request.query} language={"graphql"} />
-            {Boolean(Object.keys(request.variables).length) && (
+            {isVariablesPopulated(request) && (
               <div className="bg-gray-200 dark:bg-gray-800 rounded-lg">
                 <CodeBlock
                   text={safeJson.stringify(request.variables, undefined, 2)}

--- a/src/helpers/graphqlHelpers.test.ts
+++ b/src/helpers/graphqlHelpers.test.ts
@@ -1,4 +1,8 @@
-import { getPrimaryOperation, getErrorMessages } from "./graphqlHelpers";
+import {
+  getPrimaryOperation,
+  getErrorMessages,
+  parseGraphqlRequest,
+} from "./graphqlHelpers";
 
 describe("GraphQL Helpers", () => {
   describe("getPrimaryOperation", () => {
@@ -119,6 +123,77 @@ describe("GraphQL Helpers", () => {
       );
 
       expect(operation).toEqual(null);
+    });
+  });
+
+  describe("parseGraphqlRequest", () => {
+    it("returns an array of objects when the string given parses to an array", () => {
+      const res = parseGraphqlRequest(
+        JSON.stringify([
+          {
+            query: "",
+            variables: {},
+          },
+          {
+            query: "",
+            variables: {},
+          },
+        ])
+      );
+
+      expect(res).toMatchObject([
+        {
+          query: "",
+          variables: {},
+        },
+        {
+          query: "",
+          variables: {},
+        },
+      ]);
+    });
+
+    it("returns an array of objects when the string given parses to a single object", () => {
+      const res = parseGraphqlRequest(
+        JSON.stringify({
+          query: "",
+          variables: {},
+        })
+      );
+
+      expect(res).toMatchObject([
+        {
+          query: "",
+          variables: {},
+        },
+      ]);
+    });
+
+    it("returns null if the parsed string does not contain the query key", () => {
+      const res = parseGraphqlRequest(
+        JSON.stringify({
+          variables: {},
+        })
+      );
+
+      expect(res).toBeNull();
+    });
+
+    it("returns null if the parsed string does not contain a bad variables key", () => {
+      const res = parseGraphqlRequest(
+        JSON.stringify({
+          query: "",
+          variables: 2,
+        })
+      );
+
+      expect(res).toBeNull();
+    });
+
+    it("returns null if the parsed string is malformed", () => {
+      const res = parseGraphqlRequest("bad json");
+
+      expect(res).toBeNull();
     });
   });
 

--- a/src/hooks/useNetworkMonitor.ts
+++ b/src/hooks/useNetworkMonitor.ts
@@ -20,7 +20,7 @@ export type NetworkRequest = {
     headers: Header[];
     body: {
       query: string;
-      variables: object;
+      variables?: object;
     }[];
     headersSize: number;
     bodySize: number;
@@ -46,9 +46,11 @@ export const useNetworkMonitor = (): [NetworkRequest[], () => void] => {
       }
 
       const requestId = uuid();
-      const requestBody = parseGraphqlRequest(details.request.postData?.text);
+      const graphqlRequestBody = parseGraphqlRequest(
+        details.request.postData?.text
+      );
 
-      if (!requestBody) {
+      if (!graphqlRequestBody) {
         return;
       }
 
@@ -61,7 +63,7 @@ export const useNetworkMonitor = (): [NetworkRequest[], () => void] => {
           request: {
             primaryOperation,
             headers: details.request.headers,
-            body: requestBody,
+            body: graphqlRequestBody,
             headersSize: details.request.headersSize,
             bodySize: details.request.bodySize,
           },


### PR DESCRIPTION
When parsing the graphql request the code was not type-safe since we just assumed that the parsed object was valid. Fixed by adding a type-guard to validate the object shape.