### PR TITLE
consistent props and hide tracing tab if not available

### DIFF
--- a/src/containers/Main/Main.test.tsx
+++ b/src/containers/Main/Main.test.tsx
@@ -20,7 +20,7 @@ const mockOnNavigated = () => {
           addListener: (cb: any) => {
             triggerOnNavigated = cb;
           },
-          removeListener: () => { },
+          removeListener: () => {},
         },
       },
     },
@@ -209,6 +209,7 @@ describe("Main", () => {
       }
     });
   });
+
   it("filters network data with the given search query inverted", async () => {
     const { getByTestId, queryByTestId } = render(<Main />);
     const table = queryByTestId("network-table");
@@ -220,7 +221,7 @@ describe("Main", () => {
     });
 
     act(() => {
-      fireEvent.click(getByTestId("is-inverted-checkbox"));
+      fireEvent.click(getByTestId("inverted-checkbox"));
     });
 
     act(() => {

--- a/src/containers/NetworkPanel/NetworkDetails/TracingView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/TracingView.tsx
@@ -2,6 +2,7 @@ import { TracingVisualization } from "@/components/TracingVisualization";
 import { IResponseBody } from "@/types";
 import { useMemo } from "react";
 import * as safeJson from "@/helpers/safeJson";
+import { useApolloTracing } from "@/hooks/useApolloTracing";
 
 interface ITracingViewProps {
   response?: string;
@@ -9,11 +10,7 @@ interface ITracingViewProps {
 
 export const TracingView = (props: ITracingViewProps) => {
   const { response } = props;
-  const tracing = useMemo(() => {
-    const parsedResponse = safeJson.parse<IResponseBody>(response) || {};
-    const tracing = parsedResponse?.extensions?.tracing;
-    return tracing;
-  }, [response]);
+  const tracing = useApolloTracing(response);
 
   return (
     <div className="relative p-4">
@@ -22,6 +19,6 @@ export const TracingView = (props: ITracingViewProps) => {
       ) : (
         <p>No tracing found.</p>
       )}
-    </div >
+    </div>
   );
 };

--- a/src/containers/NetworkPanel/NetworkDetails/TracingView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/TracingView.tsx
@@ -1,7 +1,4 @@
 import { TracingVisualization } from "@/components/TracingVisualization";
-import { IResponseBody } from "@/types";
-import { useMemo } from "react";
-import * as safeJson from "@/helpers/safeJson";
 import { useApolloTracing } from "@/hooks/useApolloTracing";
 
 interface ITracingViewProps {

--- a/src/containers/NetworkPanel/NetworkDetails/index.test.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/index.test.tsx
@@ -2,7 +2,7 @@ import { render } from "@testing-library/react";
 import { TracingView } from "./TracingView";
 import * as safeJson from "../../../helpers/safeJson";
 
-describe('NetworkDetails - TracingView', () => {
+describe("NetworkDetails - TracingView", () => {
   it("show 'No tracing' message when the tracing object is null", async () => {
     const noTracingResponse = safeJson.stringify({
       data: {
@@ -10,16 +10,16 @@ describe('NetworkDetails - TracingView', () => {
           id: "1",
           firstName: "Test",
           lastName: "User",
-        }
-      }
-    })
+        },
+      },
+    });
 
     const { queryByText } = render(
       <TracingView response={noTracingResponse} />
-    )
+    );
 
-    expect(queryByText('No tracing found.')).toBeVisible();
-  })
+    expect(queryByText("No tracing found.")).toBeVisible();
+  });
 
   it("show total request time", async () => {
     const withTracingResponse = safeJson.stringify({
@@ -33,15 +33,15 @@ describe('NetworkDetails - TracingView', () => {
           },
         },
       },
-    })
+    });
 
     const { getByText } = render(
       <TracingView response={withTracingResponse} />
-    )
+    );
 
-    expect(getByText('Total')).toBeVisible();
-    expect(getByText('24.09 ms')).toBeVisible();
-  })
+    expect(getByText("Total")).toBeVisible();
+    expect(getByText("24.09 ms")).toBeVisible();
+  });
 
   it("visualize the execution trace", async () => {
     const withTracingResponse = safeJson.stringify({
@@ -86,22 +86,22 @@ describe('NetworkDetails - TracingView', () => {
           },
         },
       },
-    })
+    });
 
     const { getByText } = render(
       <TracingView response={withTracingResponse} />
-    )
+    );
 
-    expect(getByText('signedInUser')).toBeVisible();
-    expect(getByText('0.15 ms')).toBeVisible();
+    expect(getByText("signedInUser")).toBeVisible();
+    expect(getByText("0.15 ms")).toBeVisible();
 
-    expect(getByText('signedInUser.id')).toBeVisible();
-    expect(getByText('0.1 ms')).toBeVisible();
+    expect(getByText("signedInUser.id")).toBeVisible();
+    expect(getByText("0.1 ms")).toBeVisible();
 
-    expect(getByText('signedInUser.firstName')).toBeVisible();
-    expect(getByText('0.7 ms')).toBeVisible();
+    expect(getByText("signedInUser.firstName")).toBeVisible();
+    expect(getByText("0.7 ms")).toBeVisible();
 
-    expect(getByText('signedInUser.lastName')).toBeVisible();
-    expect(getByText('0.75 ms')).toBeVisible();
-  })
-})
+    expect(getByText("signedInUser.lastName")).toBeVisible();
+    expect(getByText("0.75 ms")).toBeVisible();
+  });
+});

--- a/src/containers/NetworkPanel/NetworkDetails/index.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/index.tsx
@@ -7,6 +7,7 @@ import { ResponseRawView } from "./ResponseRawView";
 import { useNetworkTabs } from "../../../hooks/useNetworkTabs";
 import { CloseButton } from "../../../components/CloseButton";
 import { TracingView } from "./TracingView";
+import { useApolloTracing } from "@/hooks/useApolloTracing";
 
 export type NetworkDetailsProps = {
   data: NetworkRequest;
@@ -20,6 +21,7 @@ export const NetworkDetails = (props: NetworkDetailsProps) => {
   const responseHeaders = data.response?.headers || [];
   const requestBody = data.request.body;
   const responseBody = data.response?.body;
+  const tracing = useApolloTracing(responseBody);
 
   return (
     <Tabs
@@ -53,11 +55,15 @@ export const NetworkDetails = (props: NetworkDetailsProps) => {
           title: "Response (Raw)",
           component: <ResponseRawView response={responseBody} />,
         },
-        {
-          id: "tracing",
-          title: "Tracing",
-          component: <TracingView response={responseBody} />,
-        },
+        ...(tracing
+          ? [
+              {
+                id: "tracing",
+                title: "Tracing",
+                component: <TracingView response={responseBody} />,
+              },
+            ]
+          : []),
       ]}
     />
   );

--- a/src/containers/NetworkPanel/index.tsx
+++ b/src/containers/NetworkPanel/index.tsx
@@ -66,8 +66,8 @@ export const NetworkPanel = (props: NetworkPanelProps) => {
           onFilterValueChange={setFilterValue}
           preserveLogs={isPreserveLogs}
           onPreserveLogsChange={setIsPreserveLogs}
-          isInverted={isInverted}
-          onIsInvertedChange={setIsInverted}
+          inverted={isInverted}
+          onInvertedChange={setIsInverted}
           onClear={() => {
             setSelectedRowId(null);
             clearWebRequests();

--- a/src/containers/Toolbar/index.tsx
+++ b/src/containers/Toolbar/index.tsx
@@ -10,8 +10,8 @@ interface IToolbarProps {
   onFilterValueChange: (filterValue: string) => void;
   preserveLogs: boolean;
   onPreserveLogsChange: (preserveLogs: boolean) => void;
-  isInverted: boolean;
-  onIsInvertedChange: (isInverted: boolean) => void;
+  inverted: boolean;
+  onInvertedChange: (isInverted: boolean) => void;
   onClear: () => void;
 }
 
@@ -21,8 +21,8 @@ export const Toolbar = (props: IToolbarProps) => {
     onFilterValueChange,
     preserveLogs,
     onPreserveLogsChange,
-    isInverted,
-    onIsInvertedChange,
+    inverted,
+    onInvertedChange,
     onClear,
   } = props;
   const { setIsSearchOpen } = useSearch();
@@ -47,9 +47,9 @@ export const Toolbar = (props: IToolbarProps) => {
       <Checkbox
         id="invert"
         label="Invert"
-        checked={isInverted}
-        onChange={onIsInvertedChange}
-        testId="is-inverted-checkbox"
+        checked={inverted}
+        onChange={onInvertedChange}
+        testId="inverted-checkbox"
       />
       <Checkbox
         id="preserveLog"

--- a/src/hooks/useApolloTracing.ts
+++ b/src/hooks/useApolloTracing.ts
@@ -1,0 +1,13 @@
+import { useMemo } from "react";
+import * as safeJson from "@/helpers/safeJson";
+import { IResponseBody } from "@/types";
+
+export const useApolloTracing = (responseBody: string = "") => {
+  const tracing = useMemo(() => {
+    const parsedResponse = safeJson.parse<IResponseBody>(responseBody) || {};
+    const tracing = parsedResponse?.extensions?.tracing;
+    return tracing;
+  }, [responseBody]);
+
+  return tracing;
+};


### PR DESCRIPTION
## Description

* Hides the tracing tab if not available as this is only useful to apollo users, where as the app is for any graphql client.
* Update prop names to keep consistent

## Checklist

- [x] Displays correctly with both dark and light mode (see useTheme.ts)  
- [x]  Unit/Integration tests added