### PR TITLE
Makes operation badges red on error

### DIFF
--- a/src/containers/NetworkPanel/NetworkTable/index.tsx
+++ b/src/containers/NetworkPanel/NetworkTable/index.tsx
@@ -22,18 +22,18 @@ const Operation = ({ request }: { request: NetworkRequest }) => {
   const { operation, operationName } = request.request.primaryOperation
 
   const responseBody = request.response?.body
-  const errorMessages = useMemo(
-    () => getErrorMessages(responseBody),
-    [responseBody]
-  )
+  const errorMessages = useMemo(() => getErrorMessages(responseBody), [
+    responseBody,
+  ])
+
+  const operationColor =
+    operation === "query" ? "text-green-400" : "text-indigo-400"
 
   return (
     <div className="flex items-center gap-2" data-testid="column-operation">
       <Badge>
         <span
-          className={
-            operation === "query" ? "text-green-400" : "text-indigo-400"
-          }
+          className={errorMessages?.length ? "text-red-500" : operationColor}
         >
           {operation === "query" ? "Q" : "M"}
         </span>
@@ -85,8 +85,13 @@ const Time = ({ ms }: { ms: number }) => {
 }
 
 export const NetworkTable = (props: NetworkTableProps) => {
-  const { data, onRowClick, onRowSelect, selectedRowId, showSingleColumn } =
-    props
+  const {
+    data,
+    onRowClick,
+    onRowSelect,
+    selectedRowId,
+    showSingleColumn,
+  } = props
 
   const selectNextRow = (direction: "up" | "down") => {
     const directionCount = direction === "up" ? -1 : 1


### PR DESCRIPTION
## Description
When the operation column is shrunk or when there are operations with long names the error indicator can be hidden behind a scrollbar.

To ensure requests with errors are always visible: this PR makes the operation badge appear red when there are one or more errors in the response body.

## Screenshot

### Problem
![error-slide](https://user-images.githubusercontent.com/23462213/159191761-d02f0751-0450-400e-b8db-c013683639a7.gif)
(See the error dot can disappear under other content)

### Solved
![image](https://user-images.githubusercontent.com/23462213/159193941-b9d6ef12-8dd4-439e-8a6e-240fe9e1943e.png)
![image](https://user-images.githubusercontent.com/23462213/159191781-0c741129-2284-4c66-bab6-0e5b1ea0464f.png)
(See the Q appears red in the final row)

## Alternatives Considered
- Tried setting the entire operation name to red.
  - Did not pass contrast guidelines
- Tried setting a red underline under each.
  - Colored text decoration not present in this version of tailwind

## Checklist

- [X] Displays correctly with both dark and light mode (see useTheme.ts)  
- [X] N/A ~~Unit/Integration tests added~~
