### PR TITLE
Fix issue where invalid regex crashes the app & display regex error message to user

### DIFF
--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -10,6 +10,7 @@ import { useMaintainScrollBottom } from "../../hooks/useMaintainScrollBottom"
 type RowId = string | number
 
 export type TableProps<T extends {}> = TableOptions<T> & {
+  error?: string | null
   onRowClick?: (rowId: RowId, data: Row<T>["original"]) => void
   selectedRowId?: RowId | null
   isScollBottomMaintained?: boolean
@@ -83,8 +84,14 @@ const TableBody = <T extends BaseRowData>({
 )
 
 export const Table = <T extends BaseRowData>(props: TableProps<T>) => {
-  const { columns, data, onRowClick, selectedRowId, isScollBottomMaintained } =
-    props
+  const {
+    columns,
+    data,
+    error,
+    onRowClick,
+    selectedRowId,
+    isScollBottomMaintained,
+  } = props
   const tableInstance = useTable({ columns, data })
   const { getTableProps, headerGroups } = tableInstance
   const ref = useMaintainScrollBottom({
@@ -114,11 +121,23 @@ export const Table = <T extends BaseRowData>(props: TableProps<T>) => {
           selectedRowId={selectedRowId}
         />
       </table>
-      {data.length === 0 && (
-        <div className="w-full flex flex-1 items-center justify-center">
-          <div className="p-6 text-center">No requests have been detected</div>
-        </div>
-      )}
+      {(() => {
+        if (error) {
+          return (
+            <div className="w-full flex flex-1 items-center justify-center">
+              <div className="p-6 text-center">{error}</div>
+            </div>
+          )
+        } else if (data.length === 0) {
+          return (
+            <div className="w-full flex flex-1 items-center justify-center">
+              <div className="p-6 text-center">
+                No requests have been detected
+              </div>
+            </div>
+          )
+        }
+      })()}
     </div>
   )
 }

--- a/src/containers/NetworkPanel/NetworkTable/index.test.tsx
+++ b/src/containers/NetworkPanel/NetworkTable/index.test.tsx
@@ -1,5 +1,5 @@
 import { NetworkTable } from "./index"
-import { render, fireEvent } from "@testing-library/react"
+import { render, fireEvent, within } from "@testing-library/react"
 
 const request = {
   time: 1000,
@@ -37,6 +37,7 @@ test("Selects next row when pressing the down arrow", () => {
   const { getByTestId } = render(
     <NetworkTable
       data={data}
+      error={null}
       onRowClick={() => {}}
       onRowSelect={mockOnRowSelect}
       selectedRowId="2"
@@ -54,6 +55,7 @@ test("Selects previous row when pressing the up arrow", () => {
   const { getByTestId } = render(
     <NetworkTable
       data={data}
+      error={null}
       onRowClick={() => {}}
       onRowSelect={mockOnRowSelect}
       selectedRowId="2"
@@ -71,6 +73,7 @@ test("Remains on bottom row when pressing the down arrow", () => {
   const { getByTestId } = render(
     <NetworkTable
       data={data}
+      error={null}
       onRowClick={() => {}}
       onRowSelect={mockOnRowSelect}
       selectedRowId="3"
@@ -88,6 +91,7 @@ test("Remains on top row when pressing the up arrow", () => {
   const { getByTestId } = render(
     <NetworkTable
       data={data}
+      error={null}
       onRowClick={() => {}}
       onRowSelect={mockOnRowSelect}
       selectedRowId="1"
@@ -98,4 +102,37 @@ test("Remains on top row when pressing the up arrow", () => {
   fireEvent.keyDown(table, { code: "ArrowUp" })
 
   expect(mockOnRowSelect).not.toHaveBeenCalled()
+})
+
+test("Data is empty and error is null - renders empty list message", () => {
+  const { getByTestId } = render(
+    <NetworkTable
+      data={[]}
+      error={null}
+      onRowClick={() => {}}
+      onRowSelect={() => {}}
+    />
+  )
+  const table = getByTestId("network-table")
+
+  expect(
+    within(table).getByText("No requests have been detected")
+  ).toBeInTheDocument()
+})
+
+test("Data is empty and error is not null - renders error message", () => {
+  const { getByTestId } = render(
+    <NetworkTable
+      data={[]}
+      error={"someErrorMessage"}
+      onRowClick={() => {}}
+      onRowSelect={() => {}}
+    />
+  )
+  const table = getByTestId("network-table")
+
+  expect(
+    within(table).queryByText("No requests have been detected")
+  ).not.toBeInTheDocument()
+  expect(within(table).getByText("someErrorMessage")).toBeInTheDocument()
 })

--- a/src/containers/NetworkPanel/NetworkTable/index.tsx
+++ b/src/containers/NetworkPanel/NetworkTable/index.tsx
@@ -11,6 +11,7 @@ import { getErrorMessages } from "../../../helpers/graphqlHelpers"
 
 export type NetworkTableProps = {
   data: NetworkRequest[]
+  error: string | null
   onRowClick: (rowId: string | number, row: NetworkRequest) => void
   onRowSelect: (rowId: string | number) => void
   selectedRowId?: string | number | null
@@ -85,8 +86,14 @@ const Time = ({ ms }: { ms: number }) => {
 }
 
 export const NetworkTable = (props: NetworkTableProps) => {
-  const { data, onRowClick, onRowSelect, selectedRowId, showSingleColumn } =
-    props
+  const {
+    data,
+    error,
+    onRowClick,
+    onRowSelect,
+    selectedRowId,
+    showSingleColumn,
+  } = props
 
   const selectNextRow = (direction: "up" | "down") => {
     const directionCount = direction === "up" ? -1 : 1
@@ -140,6 +147,7 @@ export const NetworkTable = (props: NetworkTableProps) => {
       <Table
         columns={columns}
         data={data}
+        error={error}
         onRowClick={onRowClick}
         selectedRowId={selectedRowId}
         isScollBottomMaintained

--- a/src/containers/NetworkPanel/index.test.tsx
+++ b/src/containers/NetworkPanel/index.test.tsx
@@ -1,0 +1,44 @@
+import { NetworkPanel } from "./index"
+import { render, fireEvent } from "@testing-library/react"
+
+test("Invalid regex is provided, regex mode is on - error message shows", () => {
+  const { getByTestId, getByText } = render(
+    <NetworkPanel
+      selectedRowId={null}
+      setSelectedRowId={() => {}}
+      networkRequests={[]}
+      clearWebRequests={() => {}}
+    />
+  )
+  const filterInput = getByTestId("filter-input")
+  const regexCheckbox = getByTestId("regex-checkbox")
+
+  // click the regex mode to be on
+  fireEvent.click(regexCheckbox)
+
+  // enter invalid regex expression
+  fireEvent.change(filterInput, { target: { value: "++" } })
+
+  expect(
+    getByText("Invalid regular expression: /++/: Nothing to repeat")
+  ).toBeInTheDocument()
+})
+
+test("Invalid regex is provided, regex mode is off - error message does not show", () => {
+  const { getByTestId, queryByText } = render(
+    <NetworkPanel
+      selectedRowId={null}
+      setSelectedRowId={() => {}}
+      networkRequests={[]}
+      clearWebRequests={() => {}}
+    />
+  )
+  const filterInput = getByTestId("filter-input")
+
+  // enter invalid regex expression
+  fireEvent.change(filterInput, { target: { value: "++" } })
+
+  expect(
+    queryByText("Invalid regular expression: /++/: Nothing to repeat")
+  ).not.toBeInTheDocument()
+})

--- a/src/containers/NetworkPanel/index.test.tsx
+++ b/src/containers/NetworkPanel/index.test.tsx
@@ -16,7 +16,7 @@ test("Invalid regex is provided, regex mode is on - error message shows", () => 
   // click the regex mode to be on
   fireEvent.click(regexCheckbox)
 
-  // enter invalid regex expression
+  // enter an invalid regex expression
   fireEvent.change(filterInput, { target: { value: "++" } })
 
   expect(
@@ -35,7 +35,7 @@ test("Invalid regex is provided, regex mode is off - error message does not show
   )
   const filterInput = getByTestId("filter-input")
 
-  // enter invalid regex expression
+  // enter an invalid regex expression
   fireEvent.change(filterInput, { target: { value: "++" } })
 
   expect(

--- a/src/containers/NetworkPanel/index.tsx
+++ b/src/containers/NetworkPanel/index.tsx
@@ -29,17 +29,13 @@ const filterNetworkRequests = (
 
   let regex: RegExp | null
   try {
-    regex = RegexParser(filterValue)
     setRegexError(null)
+    regex = options.isRegex ? RegexParser(filterValue) : null
   } catch (error) {
     let message = "Unknown Error"
     if (error instanceof Error) message = error.message
-    if (options.isRegex) {
-      setRegexError(message)
-      return []
-    } else {
-      setRegexError(null)
-    }
+    setRegexError(message)
+    return []
   }
 
   return networkRequests.filter((networkRequest) => {


### PR DESCRIPTION
## Description
- Previously when entering an invalid regex to the "Filter" input on the toolbar, the app would crash. This PR fixes that issue as well as adding functionality so that the regex error message is shown to the user when they are in the regex filter mode. 

## Screenshots

### Previous Behaviour (dark mode)

<a href="https://gyazo.com/8972c5fce6634c7c9b47ea5bd5a22f83"><img src="https://i.gyazo.com/8972c5fce6634c7c9b47ea5bd5a22f83.gif" alt="Image from Gyazo" width="1000"/></a>

### New Behaviour (dark mode)

<a href="https://gyazo.com/580a6c2f7accddc70e96b2abd00e23f6"><img src="https://i.gyazo.com/580a6c2f7accddc70e96b2abd00e23f6.gif" alt="Image from Gyazo" width="1000"/></a>

### Previous Behaviour (light mode)

<a href="https://gyazo.com/231c79f55205d5f6715877600d7d8224"><img src="https://i.gyazo.com/231c79f55205d5f6715877600d7d8224.gif" alt="Image from Gyazo" width="1000"/></a>

### New Behaviour (light mode)

<a href="https://gyazo.com/1a0569c2d3a21354e64751e519600256"><img src="https://i.gyazo.com/1a0569c2d3a21354e64751e519600256.gif" alt="Image from Gyazo" width="1000"/></a>

Provide a screenshot or gif of the new feature in both dark and light mode.

## Checklist

[x] Displays correctly with both dark and light mode (see useTheme.ts)  
[x] Unit/Integration tests added
