### PR TITLE
feat: add firefox build

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -3,6 +3,7 @@
 
 const path = require("path")
 const CopyWebpackPlugin = require("copy-webpack-plugin")
+const BrowserWebpackPlugin = require("./webpack/browserWebpackPlugin")
 
 module.exports = ({ env }) => {
   const isEnvDevelopment = env === "development"
@@ -36,6 +37,9 @@ module.exports = ({ env }) => {
               },
             },
           ],
+        }),
+        new BrowserWebpackPlugin({
+          buildTarget: process.env?.BUILD_TARGET ?? "chrome",
         }),
       ],
     },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "craco start",
     "build": "INLINE_RUNTIME_CHUNK=false craco build",
+    "build:firefox": "BUILD_TARGET='firefox' INLINE_RUNTIME_CHUNK=false craco build",
     "bundle": "yarn build && bestzip build.zip build/*",
     "postbuild": "node ./scripts/set-manifest-version.js",
     "test": "craco test",

--- a/public/devtools/devtools.firefox.js
+++ b/public/devtools/devtools.firefox.js
@@ -1,0 +1,6 @@
+chrome.devtools.panels.create(
+  "GraphQL Network",
+  "../icon.png",
+  "../index.html",
+  function (panel) {}
+)

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,7 +5,7 @@
   "icons": {
     "128": "icon.png"
   },
-  "manifest_version": 3,
+  "manifest_version": "{{manifest_version}}",
   "permissions": [],
   "devtools_page": "devtools/devtools.html"
 }

--- a/webpack/browserWebpackPlugin.js
+++ b/webpack/browserWebpackPlugin.js
@@ -1,0 +1,44 @@
+const fs = require("fs")
+const path = require("path")
+
+class BrowserWebpackPlugin {
+  constructor(options) {
+    this.name = "browserWebpackPlugin"
+    this.manifestPath = path.join(__dirname, "../build/manifest.json")
+    this.firefoxDevtoolsFile = path.join(
+      __dirname,
+      "../build/devtools/devtools.firefox.js"
+    )
+    this.devtoolsFile = path.join(__dirname, "../build/devtools/devtools.js")
+
+    this.isFirefox = options.buildTarget === "firefox"
+  }
+
+  apply(compiler) {
+    const pluginName = this.constructor.name
+
+    compiler.hooks.afterEmit.tap(pluginName, (_) => {
+      const manifestVersion = this.isFirefox ? 2 : 3
+
+      // Change manifest version
+      fs.readFile(this.manifestPath, "utf-8", (_, manifestFile) => {
+        const newManifestFile = manifestFile.replace(
+          '"{{manifest_version}}"',
+          manifestVersion
+        )
+        fs.writeFileSync(this.manifestPath, newManifestFile)
+      })
+
+      // Replace devtools with appropriate version
+      fs.readFile(this.firefoxDevtoolsFile, "utf-8", (_, file) => {
+        if (this.isFirefox) {
+          fs.writeFileSync(this.devtoolsFile, file)
+        }
+
+        return fs.unlinkSync(this.firefoxDevtoolsFile)
+      })
+    })
+  }
+}
+
+module.exports = BrowserWebpackPlugin


### PR DESCRIPTION
## Description

- This change adds a firefox build stage to this extension which outputs a firefox compatible extension.
- Let me know if there's a different way you prefer. I know writing a webpack extension might be a bit overkill... but it works 🤠

## To install locally on firefox
- Run `yarn build:firefox`
- In firefox, navigate to url `about:debugging`
- Click on `This Firefox` and `Load Temporary Add-on...` and add `build/manifest.json`