### PR TITLE
Auto-formatting with Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/graphql": "^14.5.0",
     "@types/jest": "^26.0.24",
     "@types/mark.js": "^8.11.7",
+    "@types/prettier": "^2.6.0",
     "@types/react": "^17.0.35",
     "@types/react-dom": "^17.0.11",
     "@types/react-table": "^7.0.22",
@@ -52,7 +53,7 @@
     "copy-webpack-plugin": "^6.4.1",
     "dedent": "^0.7.0",
     "postcss": "^8.4.12",
-    "prettier": "^2.4.1",
+    "prettier": "^2.6.2",
     "react-scripts": "^5.0.0",
     "tailwindcss": "^3.0.23",
     "typescript": "^4.0.3"

--- a/src/components/AutoFormatToggleButton/index.tsx
+++ b/src/components/AutoFormatToggleButton/index.tsx
@@ -1,0 +1,25 @@
+import { Button } from "../Button"
+
+type AutoFormatToggleButtonProps = {
+  active?: boolean
+  onToggle?: (value: boolean) => void
+  className?: string
+}
+
+export const AutoFormatToggleButton = (props: AutoFormatToggleButtonProps) => {
+  const { active, onToggle, className } = props
+
+  return (
+    <div className={className}>
+      <Button
+        testId="auto-format-toggle-button"
+        variant="contained"
+        onClick={() => {
+          onToggle?.(!active)
+        }}
+      >
+        {active ? "AutoFormat on" : "AutoFormat off"}
+      </Button>
+    </div>
+  )
+}

--- a/src/components/CodeView/CodeView.tsx
+++ b/src/components/CodeView/CodeView.tsx
@@ -1,6 +1,7 @@
 import { useHighlight } from "@/hooks/useHighlight"
 import { useByteSize } from "@/hooks/useBytes"
 import { useMarkSearch } from "@/hooks/useMark"
+import { useFormattedCode } from "../../hooks/useFormattedCode"
 import { DelayedLoader } from "../DelayedLoader"
 import { Spinner } from "../Spinner"
 import { config } from "../../config"
@@ -9,6 +10,7 @@ import classes from "./CodeView.module.css"
 type CodeViewProps = {
   text: string
   language: "graphql" | "json"
+  autoFormat?: boolean
 }
 
 const LoadingIndicator = () => {
@@ -29,8 +31,10 @@ const CodeTooLargeMessage = () => {
 }
 
 const CodeRenderer = (props: CodeViewProps) => {
-  const { text, language } = props
-  const { markup: jsonMarkup, loading } = useHighlight(language, text)
+  const { text, language, autoFormat } = props
+  const formattedText = useFormattedCode(text, language, autoFormat)
+
+  const { markup: jsonMarkup, loading } = useHighlight(language, formattedText)
   const ref = useMarkSearch(jsonMarkup)
 
   return (
@@ -47,7 +51,7 @@ const CodeRenderer = (props: CodeViewProps) => {
 }
 
 export const CodeView = (props: CodeViewProps) => {
-  const { text, language } = props
+  const { text, language, autoFormat } = props
   const size = useByteSize(text.length, { unit: "mb" })
 
   return (
@@ -55,7 +59,7 @@ export const CodeView = (props: CodeViewProps) => {
       {size > config.maxUsableResponseSizeMb ? (
         <CodeTooLargeMessage />
       ) : (
-        <CodeRenderer text={text} language={language} />
+        <CodeRenderer autoFormat={autoFormat} text={text} language={language} />
       )}
     </div>
   )

--- a/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
@@ -24,7 +24,7 @@ export const RequestView = (props: IRequestViewProps) => {
       {requests.map((request) => {
         return (
           <PanelSection key={request.query} className="relative">
-            <div className="flex gap-2 absolute right-3 top-3 z-10">
+            <div className="flex gap-2 absolute right-3 top-3 z-10 transition-opacity opacity-75 hover:opacity-100">
               <AutoFormatToggleButton
                 active={autoFormat}
                 onToggle={toggleAutoFormat}

--- a/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
@@ -24,21 +24,23 @@ export const RequestView = (props: IRequestViewProps) => {
       {requests.map((request) => {
         return (
           <PanelSection key={request.query} className="relative">
-            <div className="flex gap-0.5 absolute right-3 top-3 z-10">
+            <div className="flex gap-2 absolute right-3 top-3 z-10">
               <AutoFormatToggleButton
                 active={autoFormat}
                 onToggle={toggleAutoFormat}
               />{" "}
-              <CopyButton textToCopy={request.query} />
+              <CopyButton label="Copy Query" textToCopy={request.query} />{" "}
+              {isVariablesPopulated(request) && (
+                <CopyButton
+                  label="Copy Vars"
+                  textToCopy={safeJson.stringify(
+                    request.variables,
+                    undefined,
+                    2
+                  )}
+                />
+              )}
             </div>
-
-            {isVariablesPopulated(request) && (
-              <CopyButton
-                label="Copy Vars"
-                textToCopy={safeJson.stringify(request.variables, undefined, 2)}
-                className="absolute right-3 top-3 z-10 mt-14"
-              />
-            )}
             <CodeView
               text={request.query}
               language={"graphql"}

--- a/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
@@ -1,8 +1,10 @@
-import { Panels, PanelSection } from "./PanelSection"
+import { AutoFormatToggleButton } from "@/components/AutoFormatToggleButton"
 import { CodeView } from "@/components/CodeView"
 import { CopyButton } from "@/components/CopyButton"
-import * as safeJson from "@/helpers/safeJson"
 import { IGraphqlRequestBody } from "@/helpers/graphqlHelpers"
+import * as safeJson from "@/helpers/safeJson"
+import { useToggle } from "@/hooks/useToggle"
+import { Panels, PanelSection } from "./PanelSection"
 
 interface IRequestViewProps {
   requests: IGraphqlRequestBody[]
@@ -15,15 +17,21 @@ const isVariablesPopulated = (request: IGraphqlRequestBody) => {
 export const RequestView = (props: IRequestViewProps) => {
   const { requests } = props
 
+  const [autoFormat, toggleAutoFormat] = useToggle()
+
   return (
     <Panels>
       {requests.map((request) => {
         return (
           <PanelSection key={request.query} className="relative">
-            <CopyButton
-              textToCopy={request.query}
-              className="absolute right-3 top-3 z-10"
-            />
+            <div className="flex gap-0.5 absolute right-3 top-3 z-10">
+              <AutoFormatToggleButton
+                active={autoFormat}
+                onToggle={toggleAutoFormat}
+              />{" "}
+              <CopyButton textToCopy={request.query} />
+            </div>
+
             {isVariablesPopulated(request) && (
               <CopyButton
                 label="Copy Vars"
@@ -31,7 +39,11 @@ export const RequestView = (props: IRequestViewProps) => {
                 className="absolute right-3 top-3 z-10 mt-14"
               />
             )}
-            <CodeView text={request.query} language={"graphql"} />
+            <CodeView
+              text={request.query}
+              language={"graphql"}
+              autoFormat={autoFormat}
+            />
             {isVariablesPopulated(request) && (
               <div className="bg-gray-200 dark:bg-gray-800 rounded-lg">
                 <CodeView

--- a/src/hooks/useDebouncedEffect.ts
+++ b/src/hooks/useDebouncedEffect.ts
@@ -13,5 +13,6 @@ export const useDebouncedEffect = (
     return () => {
       clearTimeout(timeout)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cb, delay, ...deps])
 }

--- a/src/hooks/useFormattedCode.test.tsx
+++ b/src/hooks/useFormattedCode.test.tsx
@@ -1,0 +1,49 @@
+import { render } from "@testing-library/react"
+import { FunctionComponent } from "react"
+import { useFormattedCode } from "./useFormattedCode"
+
+const minifiedCode = `query {foo(bar:{baz:"hello world"}){id nested{thing}}}`
+
+const expectedFormattedCode = `query {
+  foo(bar: { baz: "hello world" }) {
+    id
+    nested {
+      thing
+    }
+  }
+}
+`
+
+export function testSimpleReactHook<Value>(useTest: () => Value) {
+  let result: null | Value = null
+  const Component: FunctionComponent = () => {
+    result = useTest()
+    return null
+  }
+  render(<Component />)
+  return result
+}
+
+describe("useFormattedCode", () => {
+  it("should format GraphQL code", () => {
+    const result = testSimpleReactHook(() =>
+      useFormattedCode(minifiedCode, "graphql", true)
+    )
+    expect(result).toBe(expectedFormattedCode)
+  })
+
+  it("should return unchanged code when enabled=false", () => {
+    const result = testSimpleReactHook(() =>
+      useFormattedCode(minifiedCode, "graphql", false)
+    )
+    expect(result).toBe(minifiedCode)
+  })
+
+  it("should return unchanged code when non-graphql language", () => {
+    const json = JSON.stringify({ foo: { bar: "baz" } })
+    const result = testSimpleReactHook(() =>
+      useFormattedCode(json, "json", true)
+    )
+    expect(result).toBe(json)
+  })
+})

--- a/src/hooks/useFormattedCode.ts
+++ b/src/hooks/useFormattedCode.ts
@@ -1,0 +1,28 @@
+import PrettierGraphQLParsers from "prettier/parser-graphql"
+import prettier from "prettier/standalone"
+import { useMemo } from "react"
+
+export function useFormattedCode(
+  code: string,
+  language: string,
+  enabled = true
+) {
+  return useMemo(() => {
+    if (enabled) {
+      if (language === "graphql") {
+        try {
+          return prettier.format(code, {
+            parser: language,
+            useTabs: false,
+            tabWidth: 2,
+            plugins: [PrettierGraphQLParsers],
+          })
+        } catch (e) {
+          console.error(e)
+        }
+      }
+    }
+
+    return code
+  }, [code, language, enabled])
+}

--- a/src/hooks/useToggle.ts
+++ b/src/hooks/useToggle.ts
@@ -1,0 +1,5 @@
+import { useReducer } from "react"
+
+export const useToggle = () => {
+  return useReducer((prev, value = !prev) => value, true)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1970,7 +1970,7 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/prettier@^2.1.5":
+"@types/prettier@^2.1.5", "@types/prettier@^2.6.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.6.0.tgz#efcbd41937f9ae7434c714ab698604822d890759"
   integrity sha512-G/AdOadiZhnJp0jXCaBQU449W2h716OW/EoXeYkCytxKL06X1WCXB4DZpp8TpZ8eyIJVS1cw4lrlkkSYU21cDw==
@@ -7412,7 +7412,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^2.4.1:
+prettier@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
   integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==


### PR DESCRIPTION
## Description

Adds support for auto-formatting GraphQL with Prettier. Closes #31

## Screenshot

https://user-images.githubusercontent.com/316435/167119125-149e346c-394a-4854-a56c-0bedc686c142.mov

https://user-images.githubusercontent.com/316435/167119382-da984e7b-bf1a-4d2f-9eb3-ce2209340f0b.mov

## Checklist

- [x] Displays correctly with both dark and light mode (see useTheme.ts)
- [x] Unit/Integration tests added
