### PR TITLE
handle persisted queries

### DIFF
--- a/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
@@ -20,16 +20,24 @@ const isVariablesPopulated = (request: IGraphqlRequestBody) => {
   return Object.keys(request.variables || {}).length > 0
 }
 
+const isExtensionsPopulated = (request: IGraphqlRequestBody) => {
+  return Object.keys(request.extensions || {}).length > 0
+}
+
 export const RequestView = (props: IRequestViewProps) => {
   const { requests, autoFormat } = props
 
   return (
     <Panels>
       {requests.map((request) => {
+        const hasQuery = !!request.query
+
         return (
           <PanelSection key={request.query} className="relative">
             <div className="flex flex-col items-end gap-2 absolute right-3 top-3 z-10 transition-opacity opacity-50 hover:opacity-100">
-              <CopyButton label="Copy Query" textToCopy={request.query} />
+              {hasQuery && (
+                <CopyButton label="Copy Query" textToCopy={request.query} />
+              )}
               {isVariablesPopulated(request) && (
                 <CopyButton
                   label="Copy Vars"
@@ -40,12 +48,24 @@ export const RequestView = (props: IRequestViewProps) => {
                   )}
                 />
               )}
+              {isExtensionsPopulated(request) && (
+                <CopyButton
+                  label="Copy Extensions"
+                  textToCopy={safeJson.stringify(
+                    request.extensions,
+                    undefined,
+                    2
+                  )}
+                />
+              )}
             </div>
-            <CodeView
-              text={request.query}
-              language={"graphql"}
-              autoFormat={autoFormat}
-            />
+            {hasQuery && (
+              <CodeView
+                text={request.query}
+                language={"graphql"}
+                autoFormat={autoFormat}
+              />
+            )}
             {isVariablesPopulated(request) && (
               <div className="bg-gray-200 dark:bg-gray-800 rounded-lg">
                 <CodeView
@@ -53,6 +73,13 @@ export const RequestView = (props: IRequestViewProps) => {
                   language={"json"}
                 />
               </div>
+            )}
+            {isExtensionsPopulated(request) && (
+              <CodeView
+                text={safeJson.stringify(request.extensions, undefined, 2)}
+                language={"json"}
+                autoFormat={autoFormat}
+              />
             )}
           </PanelSection>
         )

--- a/src/hooks/useNetworkMonitor.ts
+++ b/src/hooks/useNetworkMonitor.ts
@@ -36,17 +36,14 @@ export const useNetworkMonitor = (): [NetworkRequest[], () => void] => {
 
   const handleRequestFinished = useCallback(
     (details: chrome.devtools.network.Request) => {
-      const primaryOperation = getPrimaryOperation(
-        details.request.postData?.text
-      )
+      const primaryOperation = getPrimaryOperation(details)
+
       if (!primaryOperation) {
         return
       }
 
       const requestId = uuid()
-      const graphqlRequestBody = parseGraphqlRequest(
-        details.request.postData?.text
-      )
+      const graphqlRequestBody = parseGraphqlRequest(details)
 
       if (!graphqlRequestBody) {
         return

--- a/src/mocks/mock-requests.ts
+++ b/src/mocks/mock-requests.ts
@@ -35,6 +35,7 @@ const createRequest = ({
             "SIDCC=fe0e8768-3b2f-4f63-983d-1a74c26dde1efe0e8768-3b2f-4f63-983d-1a74c26dde1e; expires=Thu, 14-Apr-2022 08:09:50 GMT; path=/; domain=.google.com; priority=high",
         },
       ],
+      method: "POST",
       postData: {
         text: JSON.stringify(
           request.map(({ query, variables }) => ({


### PR DESCRIPTION
## Description

This PR should fix #70 and #71. The app now detects persisted queries (GET requests).

Note that each framework handles persisted queries differently, I only handle persisted ones I know. This can be further improved by submitting new issues for each case.

## Screenshot

Provide a screenshot or gif of the new feature in both dark and light mode.

![image](https://user-images.githubusercontent.com/6053067/221408611-82c577f3-e498-4f2a-98d8-bb204c8d6a2f.png)

![image](https://user-images.githubusercontent.com/6053067/221408726-a4bcf7e3-6ed6-4f7f-9146-adb9ec3d4818.png)

Also note that on this screenshot, there is 1 POST GraphQL query and there are 3 GET GraphQL queries.

## Checklist

- [x] Displays correctly with both dark and light mode (see useTheme.ts)
- [x] Unit/Integration tests added
