### PR TITLE
Improve design of RequestView

### DIFF
--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -12,17 +12,19 @@ export type Tab = {
 export type TabsProps = {
   tabs: Tab[]
   leftContent?: ReactNode
+  rightContent?: ReactNode
   activeTab: number
   onTabClick: (activeTab: number) => void
   testId?: string
 }
 
 export const Tabs = (props: TabsProps) => {
-  const { tabs, leftContent, activeTab, onTabClick, testId } = props
+  const { tabs, leftContent, rightContent, activeTab, onTabClick, testId } =
+    props
 
   return (
     <div className="flex flex-col h-full" data-testid={testId}>
-      <Header leftContent={leftContent}>
+      <Header leftContent={leftContent} rightContent={rightContent}>
         {tabs.map((tab, i) => {
           const isActive = i === activeTab
           return (

--- a/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
@@ -51,13 +51,28 @@ const SingleRequestView = (props: SingleRequestViewProps) => {
   const displayExtensions = isExtensionsPopulated(request)
 
   return (
-    <PanelSection>
-      <div className="flex flex-col gap-4">
+    <PanelSection className="relative">
+      <div className="flex flex-col">
+        <div className="flex items-end gap-2 absolute right-3 z-10 transition-opacity opacity-50 hover:opacity-100">
+          {displayQuery && (
+            <CopyButton label="Copy Query" textToCopy={request.query} />
+          )}
+          {displayVariables && (
+            <CopyButton
+              label="Copy Vars"
+              textToCopy={safeJson.stringify(request.variables, undefined, 2)}
+            />
+          )}
+          {displayExtensions && (
+            <CopyButton
+              label="Copy Extensions"
+              textToCopy={safeJson.stringify(request.extensions, undefined, 2)}
+            />
+          )}
+        </div>
+
         {displayQuery && (
-          <RequestViewSection
-            title="Query"
-            actions={<CopyButton label="Copy" textToCopy={request.query} />}
-          >
+          <RequestViewSection title="Query">
             <CodeView
               text={request.query}
               language={"graphql"}
@@ -66,15 +81,7 @@ const SingleRequestView = (props: SingleRequestViewProps) => {
           </RequestViewSection>
         )}
         {displayVariables && (
-          <RequestViewSection
-            title="Variables"
-            actions={
-              <CopyButton
-                label="Copy"
-                textToCopy={safeJson.stringify(request.variables, undefined, 2)}
-              />
-            }
-          >
+          <RequestViewSection title="Variables">
             <CodeView
               text={safeJson.stringify(request.variables, undefined, 2)}
               language={"json"}
@@ -82,19 +89,7 @@ const SingleRequestView = (props: SingleRequestViewProps) => {
           </RequestViewSection>
         )}
         {displayExtensions && (
-          <RequestViewSection
-            title="Extensions"
-            actions={
-              <CopyButton
-                label="Copy"
-                textToCopy={safeJson.stringify(
-                  request.extensions,
-                  undefined,
-                  2
-                )}
-              />
-            }
-          >
+          <RequestViewSection title="Extensions">
             <CodeView
               text={safeJson.stringify(request.extensions, undefined, 2)}
               language={"json"}
@@ -109,17 +104,15 @@ const SingleRequestView = (props: SingleRequestViewProps) => {
 
 type RequestViewSectionProps = {
   title: string
-  actions: ReactNode
 }
 
 const RequestViewSection: FC<RequestViewSectionProps> = (props) => {
-  const { title, actions, children } = props
+  const { title, children } = props
 
   return (
     <div>
-      <div className="flex justify-between items-center">
+      <div className="flex justify-between items-center mt-3">
         <span className="font-bold mb-4">{title}</span>
-        {actions}
       </div>
       <div className="bg-gray-200 dark:bg-gray-800 rounded-lg">{children}</div>
     </div>

--- a/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
@@ -5,7 +5,7 @@ import { IGraphqlRequestBody } from "@/helpers/graphqlHelpers"
 import * as safeJson from "@/helpers/safeJson"
 import { Bar } from "@/components/Bar"
 import { Panels, PanelSection } from "./PanelSection"
-import { FC, ReactNode } from "react"
+import { FC } from "react"
 
 const isVariablesPopulated = (request: IGraphqlRequestBody) => {
   return Object.keys(request.variables || {}).length > 0
@@ -23,14 +23,19 @@ interface IRequestViewProps {
 export const RequestView = (props: IRequestViewProps) => {
   const { requests, autoFormat } = props
 
+  const numberOfRequests = requests.length
+  const shouldDisplayRequestIndex = numberOfRequests > 1
+
   return (
     <Panels>
-      {requests.map((request) => {
+      {requests.map((request, index) => {
         return (
           <SingleRequestView
             key={request.query}
             request={request}
             autoFormat={autoFormat}
+            index={shouldDisplayRequestIndex && index + 1}
+            numberOfRequests={numberOfRequests}
           />
         )
       })}
@@ -41,10 +46,12 @@ export const RequestView = (props: IRequestViewProps) => {
 type SingleRequestViewProps = {
   request: IGraphqlRequestBody
   autoFormat: boolean
+  index: number | false
+  numberOfRequests: number
 }
 
 const SingleRequestView = (props: SingleRequestViewProps) => {
-  const { request, autoFormat } = props
+  const { request, autoFormat, index, numberOfRequests } = props
 
   const displayQuery = !!request.query
   const displayVariables = isVariablesPopulated(request)
@@ -72,7 +79,9 @@ const SingleRequestView = (props: SingleRequestViewProps) => {
         </div>
 
         {displayQuery && (
-          <RequestViewSection title="Query">
+          <RequestViewSection
+            title={"Query" + (index ? ` (${index}/${numberOfRequests})` : "")}
+          >
             <CodeView
               text={request.query}
               language={"graphql"}

--- a/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
@@ -5,16 +5,7 @@ import { IGraphqlRequestBody } from "@/helpers/graphqlHelpers"
 import * as safeJson from "@/helpers/safeJson"
 import { Bar } from "@/components/Bar"
 import { Panels, PanelSection } from "./PanelSection"
-
-interface IRequestViewProps {
-  autoFormat: boolean
-  requests: IGraphqlRequestBody[]
-}
-
-interface IRequestViewFooterProps {
-  autoFormat: boolean
-  toggleAutoFormat: React.DispatchWithoutAction
-}
+import { FC, ReactNode } from "react"
 
 const isVariablesPopulated = (request: IGraphqlRequestBody) => {
   return Object.keys(request.variables || {}).length > 0
@@ -24,68 +15,120 @@ const isExtensionsPopulated = (request: IGraphqlRequestBody) => {
   return Object.keys(request.extensions || {}).length > 0
 }
 
+interface IRequestViewProps {
+  autoFormat: boolean
+  requests: IGraphqlRequestBody[]
+}
+
 export const RequestView = (props: IRequestViewProps) => {
   const { requests, autoFormat } = props
 
   return (
     <Panels>
       {requests.map((request) => {
-        const hasQuery = !!request.query
-
         return (
-          <PanelSection key={request.query} className="relative">
-            <div className="flex flex-col items-end gap-2 absolute right-3 top-3 z-10 transition-opacity opacity-50 hover:opacity-100">
-              {hasQuery && (
-                <CopyButton label="Copy Query" textToCopy={request.query} />
-              )}
-              {isVariablesPopulated(request) && (
-                <CopyButton
-                  label="Copy Vars"
-                  textToCopy={safeJson.stringify(
-                    request.variables,
-                    undefined,
-                    2
-                  )}
-                />
-              )}
-              {isExtensionsPopulated(request) && (
-                <CopyButton
-                  label="Copy Extensions"
-                  textToCopy={safeJson.stringify(
-                    request.extensions,
-                    undefined,
-                    2
-                  )}
-                />
-              )}
-            </div>
-            {hasQuery && (
-              <CodeView
-                text={request.query}
-                language={"graphql"}
-                autoFormat={autoFormat}
-              />
-            )}
-            {isVariablesPopulated(request) && (
-              <div className="bg-gray-200 dark:bg-gray-800 rounded-lg">
-                <CodeView
-                  text={safeJson.stringify(request.variables, undefined, 2)}
-                  language={"json"}
-                />
-              </div>
-            )}
-            {isExtensionsPopulated(request) && (
-              <CodeView
-                text={safeJson.stringify(request.extensions, undefined, 2)}
-                language={"json"}
-                autoFormat={autoFormat}
-              />
-            )}
-          </PanelSection>
+          <SingleRequestView
+            key={request.query}
+            request={request}
+            autoFormat={autoFormat}
+          />
         )
       })}
     </Panels>
   )
+}
+
+type SingleRequestViewProps = {
+  request: IGraphqlRequestBody
+  autoFormat: boolean
+}
+
+const SingleRequestView = (props: SingleRequestViewProps) => {
+  const { request, autoFormat } = props
+
+  const displayQuery = !!request.query
+  const displayVariables = isVariablesPopulated(request)
+  const displayExtensions = isExtensionsPopulated(request)
+
+  return (
+    <PanelSection>
+      <div className="flex flex-col gap-4">
+        {displayQuery && (
+          <RequestViewSection
+            title="Query"
+            actions={<CopyButton label="Copy" textToCopy={request.query} />}
+          >
+            <CodeView
+              text={request.query}
+              language={"graphql"}
+              autoFormat={autoFormat}
+            />
+          </RequestViewSection>
+        )}
+        {displayVariables && (
+          <RequestViewSection
+            title="Variables"
+            actions={
+              <CopyButton
+                label="Copy"
+                textToCopy={safeJson.stringify(request.variables, undefined, 2)}
+              />
+            }
+          >
+            <CodeView
+              text={safeJson.stringify(request.variables, undefined, 2)}
+              language={"json"}
+            />
+          </RequestViewSection>
+        )}
+        {displayExtensions && (
+          <RequestViewSection
+            title="Extensions"
+            actions={
+              <CopyButton
+                label="Copy"
+                textToCopy={safeJson.stringify(
+                  request.extensions,
+                  undefined,
+                  2
+                )}
+              />
+            }
+          >
+            <CodeView
+              text={safeJson.stringify(request.extensions, undefined, 2)}
+              language={"json"}
+              autoFormat={autoFormat}
+            />
+          </RequestViewSection>
+        )}
+      </div>
+    </PanelSection>
+  )
+}
+
+type RequestViewSectionProps = {
+  title: string
+  actions: ReactNode
+}
+
+const RequestViewSection: FC<RequestViewSectionProps> = (props) => {
+  const { title, actions, children } = props
+
+  return (
+    <div>
+      <div className="flex justify-between items-center">
+        <span className="font-bold mb-4">{title}</span>
+        {actions}
+      </div>
+      <div className="bg-gray-200 dark:bg-gray-800 rounded-lg">{children}</div>
+    </div>
+  )
+}
+
+interface IRequestViewFooterProps {
+  autoFormat: boolean
+  toggleAutoFormat: React.DispatchWithoutAction
 }
 
 export const RequestViewFooter = (props: IRequestViewFooterProps) => {


### PR DESCRIPTION
## Description

Improve the design of the RequestView component, based on the HeadersView design.

* The close icon is now back on the left (I think this is a regression because on the readme screen, it is on the left)
* Each "section" in the RequestView now has a visible title and a list of actions (copy) to the right

## Screenshot

![image](https://user-images.githubusercontent.com/6053067/222525754-f821c99b-aaf2-471a-acbc-c7a6809d9206.png)

![image](https://user-images.githubusercontent.com/6053067/222526208-9c7fe23e-873a-4fa0-832b-a75fa23e9c01.png)


## Checklist

- [x] Displays correctly with both dark and light mode (see useTheme.ts)
