### PR TITLE
add quick filters on queries and mutations

### DIFF
--- a/src/components/Button/index.test.tsx
+++ b/src/components/Button/index.test.tsx
@@ -1,0 +1,24 @@
+import { render, fireEvent } from "@testing-library/react"
+import { Button } from "./"
+
+const testId = "button"
+
+test("renders a <Button/>", () => {
+  const { getByTestId } = render(<Button testId={testId}>Hello</Button>)
+  expect(getByTestId(testId)).toHaveTextContent("Hello")
+})
+
+test("fires an event when clicked", () => {
+  const onClickFn = jest.fn()
+
+  const { getByTestId } = render(<Button testId={testId} onClick={onClickFn} />)
+
+  fireEvent.click(getByTestId(testId))
+
+  expect(onClickFn).toHaveBeenCalled()
+})
+
+test("should be of type button", () => {
+  const { getByTestId } = render(<Button testId={testId} />)
+  expect(getByTestId(testId)).toHaveAttribute("type", "button")
+})

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -35,6 +35,7 @@ export const Button: FC<IButtonProps> = (props) => {
 
   return (
     <button
+      type="button"
       onClick={onClick}
       className={cx(
         "flex justify-center items-center rounded-lg font-bold transition",

--- a/src/containers/NetworkPanel/NetworkTable/index.test.tsx
+++ b/src/containers/NetworkPanel/NetworkTable/index.test.tsx
@@ -1,5 +1,6 @@
 import { NetworkTable } from "./index"
 import { render, fireEvent, within } from "@testing-library/react"
+import { QuickFilters } from ".."
 
 const request = {
   time: 1000,
@@ -32,6 +33,12 @@ const data = [
   },
 ] as any[]
 
+const quickFilters: QuickFilters = {
+  query: true,
+  mutation: true,
+  subscription: true,
+}
+
 test("Selects next row when pressing the down arrow", () => {
   const mockOnRowSelect = jest.fn()
   const { getByTestId } = render(
@@ -40,6 +47,8 @@ test("Selects next row when pressing the down arrow", () => {
       onRowClick={() => {}}
       onRowSelect={mockOnRowSelect}
       selectedRowId="2"
+      quickFilters={quickFilters}
+      onQuickFilterButtonClicked={() => {}}
     />
   )
   const table = getByTestId("network-table")
@@ -57,6 +66,8 @@ test("Selects previous row when pressing the up arrow", () => {
       onRowClick={() => {}}
       onRowSelect={mockOnRowSelect}
       selectedRowId="2"
+      quickFilters={quickFilters}
+      onQuickFilterButtonClicked={() => {}}
     />
   )
   const table = getByTestId("network-table")
@@ -74,6 +85,8 @@ test("Remains on bottom row when pressing the down arrow", () => {
       onRowClick={() => {}}
       onRowSelect={mockOnRowSelect}
       selectedRowId="3"
+      quickFilters={quickFilters}
+      onQuickFilterButtonClicked={() => {}}
     />
   )
   const table = getByTestId("network-table")
@@ -91,6 +104,8 @@ test("Remains on top row when pressing the up arrow", () => {
       onRowClick={() => {}}
       onRowSelect={mockOnRowSelect}
       selectedRowId="1"
+      quickFilters={quickFilters}
+      onQuickFilterButtonClicked={() => {}}
     />
   )
   const table = getByTestId("network-table")
@@ -102,7 +117,13 @@ test("Remains on top row when pressing the up arrow", () => {
 
 test("data is empty - empty table message is rendered", () => {
   const { getByTestId } = render(
-    <NetworkTable data={[]} onRowClick={() => {}} onRowSelect={() => {}} />
+    <NetworkTable
+      data={[]}
+      onRowClick={() => {}}
+      onRowSelect={() => {}}
+      quickFilters={quickFilters}
+      onQuickFilterButtonClicked={() => {}}
+    />
   )
   const table = getByTestId("network-table")
 
@@ -119,6 +140,8 @@ test("data is empty and an error message is provided - error message is rendered
       error={"someErrorMessage"}
       onRowClick={() => {}}
       onRowSelect={() => {}}
+      quickFilters={quickFilters}
+      onQuickFilterButtonClicked={() => {}}
     />
   )
   const table = getByTestId("network-table")

--- a/src/containers/NetworkPanel/NetworkTable/index.tsx
+++ b/src/containers/NetworkPanel/NetworkTable/index.tsx
@@ -7,7 +7,12 @@ import { Badge } from "../../../components/Badge"
 import { getStatusColor } from "../../../helpers/getStatusColor"
 import { NetworkRequest } from "../../../hooks/useNetworkMonitor"
 import { useKeyDown } from "../../../hooks/useKeyDown"
-import { getErrorMessages } from "../../../helpers/graphqlHelpers"
+import {
+  getErrorMessages,
+  OperationType,
+} from "../../../helpers/graphqlHelpers"
+import { QuickFilters } from ".."
+import { QuickFiltersContainer } from "../QuickFiltersContainer"
 
 export type NetworkTableProps = {
   data: NetworkRequest[]
@@ -16,6 +21,8 @@ export type NetworkTableProps = {
   onRowSelect: (rowId: string | number) => void
   selectedRowId?: string | number | null
   showSingleColumn?: boolean
+  quickFilters: QuickFilters
+  onQuickFilterButtonClicked: (filter: OperationType) => void
 }
 
 const Operation = ({ request }: { request: NetworkRequest }) => {
@@ -23,9 +30,10 @@ const Operation = ({ request }: { request: NetworkRequest }) => {
   const { operation, operationName } = request.request.primaryOperation
 
   const responseBody = request.response?.body
-  const errorMessages = useMemo(() => getErrorMessages(responseBody), [
-    responseBody,
-  ])
+  const errorMessages = useMemo(
+    () => getErrorMessages(responseBody),
+    [responseBody]
+  )
 
   const operationColor =
     operation === "query" ? "text-green-400" : "text-indigo-400"
@@ -93,6 +101,8 @@ export const NetworkTable = (props: NetworkTableProps) => {
     onRowSelect,
     selectedRowId,
     showSingleColumn,
+    quickFilters,
+    onQuickFilterButtonClicked,
   } = props
 
   const selectNextRow = (direction: "up" | "down") => {
@@ -141,7 +151,7 @@ export const NetworkTable = (props: NetworkTableProps) => {
 
   return (
     <div
-      className="w-full relative h-full dark:bg-gray-900"
+      className="w-full h-full flex flex-col relative dark:bg-gray-900"
       data-testid="network-table"
     >
       <Table
@@ -151,6 +161,11 @@ export const NetworkTable = (props: NetworkTableProps) => {
         onRowClick={onRowClick}
         selectedRowId={selectedRowId}
         isScollBottomMaintained
+      />
+
+      <QuickFiltersContainer
+        quickFilters={quickFilters}
+        onQuickFilterButtonClicked={onQuickFilterButtonClicked}
       />
     </div>
   )

--- a/src/containers/NetworkPanel/QuickFiltersContainer/index.tsx
+++ b/src/containers/NetworkPanel/QuickFiltersContainer/index.tsx
@@ -1,0 +1,40 @@
+import { Button } from "@/components/Button"
+import { OperationType } from "@/helpers/graphqlHelpers"
+import cx from "classnames"
+import { QuickFilters } from ".."
+
+export type QuickFiltersContainerProps = {
+  quickFilters: QuickFilters
+  onQuickFilterButtonClicked: (filter: OperationType) => void
+}
+
+export const QuickFiltersContainer = (props: QuickFiltersContainerProps) => {
+  const { quickFilters, onQuickFilterButtonClicked } = props
+
+  return (
+    <div className="bg-gray-200 dark:bg-gray-800 p-1.5 max-w-full">
+      <div className="flex gap-2">
+        <Button
+          onClick={() => onQuickFilterButtonClicked("query")}
+          className={cx(
+            "p-1 px-2.5",
+            quickFilters["query"] &&
+              "bg-green-400 hover:bg-green-300 !text-gray-800"
+          )}
+        >
+          Queries
+        </Button>
+        <Button
+          onClick={() => onQuickFilterButtonClicked("mutation")}
+          className={cx(
+            "p-1 px-2.5",
+            quickFilters["mutation"] &&
+              "bg-indigo-400 hover:bg-indigo-300 !text-gray-800"
+          )}
+        >
+          Mutations
+        </Button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Description

Fix #78. Display toggle buttons to filters the list of queries and mutations.

## Screenshot

![image](https://user-images.githubusercontent.com/6053067/222895942-9fbf16e3-47d4-47a9-a73b-c8ac05b4dc67.png)

![image](https://user-images.githubusercontent.com/6053067/222895950-30a25b9f-4d35-4548-a2dc-84e702ed6f1a.png)

Here are some versions when toggle changed:

![image](https://user-images.githubusercontent.com/6053067/222895967-d099567b-efa8-4c9e-9495-fc0d8b2aa086.png)

![image](https://user-images.githubusercontent.com/6053067/222895983-60d0613c-3d29-4f5a-99d3-87be7743a554.png)


## Checklist

- [x] Displays correctly with both dark and light mode (see useTheme.ts)
- [x] Unit/Integration tests added
