### PR TITLE
Support persisted queries for POST requests

### DIFF
--- a/src/containers/NetworkPanel/NetworkTable/index.test.tsx
+++ b/src/containers/NetworkPanel/NetworkTable/index.test.tsx
@@ -36,6 +36,7 @@ const data = [
 const quickFilters: QuickFilters = {
   query: true,
   mutation: true,
+  persisted: true,
   subscription: true,
 }
 

--- a/src/containers/NetworkPanel/NetworkTable/index.tsx
+++ b/src/containers/NetworkPanel/NetworkTable/index.tsx
@@ -18,14 +18,14 @@ const OperationAliases: Record<OperationType, string> = {
   query: "Q",
   mutation: "M",
   subscription: "S",
-  unknown: "U",
+  persisted: "P",
 }
 
 const OperationColors: Record<OperationType, string> = {
   query: "text-green-400",
   mutation: "text-indigo-400",
   subscription: "",
-  unknown: "text-yellow-400",
+  persisted: "text-yellow-400",
 }
 
 export type NetworkTableProps = {

--- a/src/containers/NetworkPanel/NetworkTable/index.tsx
+++ b/src/containers/NetworkPanel/NetworkTable/index.tsx
@@ -14,6 +14,20 @@ import {
 import { QuickFilters } from ".."
 import { QuickFiltersContainer } from "../QuickFiltersContainer"
 
+const OperationAliases: Record<OperationType, string> = {
+  query: "Q",
+  mutation: "M",
+  subscription: "S",
+  unknown: "U",
+}
+
+const OperationColors: Record<OperationType, string> = {
+  query: "text-green-400",
+  mutation: "text-indigo-400",
+  subscription: "",
+  unknown: "text-yellow-400",
+}
+
 export type NetworkTableProps = {
   data: NetworkRequest[]
   error?: string
@@ -35,8 +49,7 @@ const Operation = ({ request }: { request: NetworkRequest }) => {
     [responseBody]
   )
 
-  const operationColor =
-    operation === "query" ? "text-green-400" : "text-indigo-400"
+  const operationColor = OperationColors[operation]
 
   return (
     <div className="flex items-center gap-2" data-testid="column-operation">
@@ -44,7 +57,7 @@ const Operation = ({ request }: { request: NetworkRequest }) => {
         <span
           className={errorMessages?.length ? "text-red-500" : operationColor}
         >
-          {operation === "query" ? "Q" : "M"}
+          {OperationAliases[operation]}
         </span>
       </Badge>
 

--- a/src/containers/NetworkPanel/QuickFiltersContainer/index.tsx
+++ b/src/containers/NetworkPanel/QuickFiltersContainer/index.tsx
@@ -48,15 +48,17 @@ export const QuickFiltersContainer = (props: QuickFiltersContainerProps) => {
           Mutations
         </Button>
         <Button
-          variant={quickFilters.unknown ? "primary" : "ghost"}
-          onClick={() => onQuickFilterButtonClicked("unknown")}
+          variant={quickFilters.persisted ? "primary" : "ghost"}
+          onClick={() => onQuickFilterButtonClicked("persisted")}
           icon={
             <Pill
-              className={quickFilters.unknown ? "bg-yellow-400" : "bg-gray-400"}
+              className={
+                quickFilters.persisted ? "bg-yellow-400" : "bg-gray-400"
+              }
             />
           }
         >
-          Unknowns
+          Persisted
         </Button>
       </div>
     </Bar>

--- a/src/containers/NetworkPanel/QuickFiltersContainer/index.tsx
+++ b/src/containers/NetworkPanel/QuickFiltersContainer/index.tsx
@@ -47,6 +47,17 @@ export const QuickFiltersContainer = (props: QuickFiltersContainerProps) => {
         >
           Mutations
         </Button>
+        <Button
+          variant={quickFilters.unknown ? "primary" : "ghost"}
+          onClick={() => onQuickFilterButtonClicked("unknown")}
+          icon={
+            <Pill
+              className={quickFilters.unknown ? "bg-yellow-400" : "bg-gray-400"}
+            />
+          }
+        >
+          Unknowns
+        </Button>
       </div>
     </Bar>
   )

--- a/src/containers/NetworkPanel/index.tsx
+++ b/src/containers/NetworkPanel/index.tsx
@@ -73,7 +73,7 @@ export const NetworkPanel = (props: NetworkPanelProps) => {
   const [quickFilters, setQuickFilters] = useState<QuickFilters>({
     query: true,
     mutation: true,
-    unknown: true,
+    persisted: true,
     subscription: false,
   })
 

--- a/src/containers/NetworkPanel/index.tsx
+++ b/src/containers/NetworkPanel/index.tsx
@@ -73,6 +73,7 @@ export const NetworkPanel = (props: NetworkPanelProps) => {
   const [quickFilters, setQuickFilters] = useState<QuickFilters>({
     query: true,
     mutation: true,
+    unknown: true,
     subscription: false,
   })
 

--- a/src/helpers/graphqlHelpers.test.ts
+++ b/src/helpers/graphqlHelpers.test.ts
@@ -211,7 +211,7 @@ describe("GraphQL Helpers", () => {
 
       expect(operation).toEqual({
         operationName: "createMovie",
-        operation: "unknown",
+        operation: "persisted",
       })
     })
 

--- a/src/helpers/graphqlHelpers.test.ts
+++ b/src/helpers/graphqlHelpers.test.ts
@@ -84,7 +84,7 @@ describe("GraphQL Helpers", () => {
                     firstName
                     lastName
                   }
-    
+
                   query getMovieQuery($title: String) {
                     getMovie(title: $title) {
                       id
@@ -160,7 +160,7 @@ describe("GraphQL Helpers", () => {
       expect(operation).toEqual(null)
     })
 
-    it("gets the primary operation name for a persisted query", () => {
+    it("gets the primary operation name for a GET persisted query", () => {
       const request = {
         request: {
           method: "GET",
@@ -183,6 +183,35 @@ describe("GraphQL Helpers", () => {
       expect(operation).toEqual({
         operationName: "getTopMovie",
         operation: "query",
+      })
+    })
+
+    it("gets the primary operation name for a POST persisted query", () => {
+      const request = {
+        request: {
+          method: "POST",
+          postData: {
+            text: JSON.stringify([
+              {
+                operationName: "createMovie",
+                extensions: {
+                  persistedQuery: {
+                    version: 1,
+                    sha256Hash:
+                      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+                  },
+                },
+              },
+            ]),
+          },
+        },
+      } as chrome.devtools.network.Request
+
+      const operation = getPrimaryOperation(request)
+
+      expect(operation).toEqual({
+        operationName: "createMovie",
+        operation: "unknown",
       })
     })
 
@@ -399,7 +428,7 @@ describe("GraphQL Helpers", () => {
       consoleError.mockRestore()
     })
 
-    it("gets an array of objects for a persisted query", () => {
+    it("gets an array of objects for a GET persisted query", () => {
       const request = {
         request: {
           method: "GET",
@@ -422,6 +451,43 @@ describe("GraphQL Helpers", () => {
       expect(res).toEqual([
         {
           query: "query getTopMovie { getTopMovie { id title genre } }",
+        },
+      ])
+    })
+
+    it("gets an array of objects for a POST persisted query", () => {
+      const request = {
+        request: {
+          method: "POST",
+          postData: {
+            text: JSON.stringify([
+              {
+                operationName: "createMovie",
+                extensions: {
+                  persistedQuery: {
+                    version: 1,
+                    sha256Hash:
+                      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+                  },
+                },
+              },
+            ]),
+          },
+        },
+      } as chrome.devtools.network.Request
+
+      const res = parseGraphqlRequest(request)
+
+      expect(res).toEqual([
+        {
+          operationName: "createMovie",
+          extensions: {
+            persistedQuery: {
+              version: 1,
+              sha256Hash:
+                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            },
+          },
         },
       ])
     })

--- a/src/helpers/graphqlHelpers.test.ts
+++ b/src/helpers/graphqlHelpers.test.ts
@@ -244,7 +244,7 @@ describe("GraphQL Helpers", () => {
 
       expect(operation).toEqual({
         operationName: "getTopMovie",
-        operation: "query",
+        operation: "persisted",
       })
     })
 

--- a/src/helpers/graphqlHelpers.ts
+++ b/src/helpers/graphqlHelpers.ts
@@ -1,7 +1,7 @@
 import { FieldNode, GraphQLError, OperationDefinitionNode } from "graphql"
 import gql from "graphql-tag"
 
-export type OperationType = "query" | "mutation" | "subscription" | "unknown"
+export type OperationType = "query" | "mutation" | "subscription" | "persisted"
 
 export interface IGraphqlRequestBody {
   query: string
@@ -234,7 +234,7 @@ export const getPrimaryOperationForPostRequest = (
       }
 
       // Can be either query or mutation here, we don't know
-      operation = "unknown"
+      operation = "persisted"
     }
 
     return {

--- a/src/helpers/graphqlHelpers.ts
+++ b/src/helpers/graphqlHelpers.ts
@@ -189,7 +189,7 @@ export const getPrimaryOperationForGetRequest = (
   if (isPersistedQuery) {
     return {
       operationName: operationNameParam.value,
-      operation: "query",
+      operation: "persisted",
     }
   }
 
@@ -226,16 +226,21 @@ export const getPrimaryOperationForPostRequest = (
       }
 
       operation = firstOperationDefinition?.operation
-    } else {
-      operationName = postData[0].operationName
 
-      if (!operationName) {
-        throw new Error("Operation name could not be determined")
+      return {
+        operationName,
+        operation,
       }
-
-      // Can be either query or mutation here, we don't know
-      operation = "persisted"
     }
+
+    operationName = postData[0].operationName
+
+    if (!operationName) {
+      throw new Error("Operation name could not be determined")
+    }
+
+    // Can be either query or mutation here, we don't know
+    operation = "persisted"
 
     return {
       operationName,

--- a/src/helpers/graphqlHelpers.ts
+++ b/src/helpers/graphqlHelpers.ts
@@ -1,7 +1,7 @@
 import { FieldNode, GraphQLError, OperationDefinitionNode } from "graphql"
 import gql from "graphql-tag"
 
-export type OperationType = "query" | "mutation" | "subscription"
+export type OperationType = "query" | "mutation" | "subscription" | "unknown"
 
 export interface IGraphqlRequestBody {
   query: string
@@ -52,7 +52,9 @@ const isParsedGraphqlRequestValid = (
   requestPayloads: any[]
 ): requestPayloads is IGraphqlRequestBody[] => {
   const isValid = requestPayloads.every((payload) => {
-    const isQueryValid = "query" in payload && typeof payload.query === "string"
+    const isQueryValid =
+      ("query" in payload && typeof payload.query === "string") ||
+      payload.extensions?.persistedQuery
     const isVariablesValid =
       "variables" in payload ? typeof payload.variables === "object" : true
     return isQueryValid && isVariablesValid
@@ -206,23 +208,38 @@ export const getPrimaryOperationForPostRequest = (
   try {
     const request = JSON.parse(requestBody)
     const postData = Array.isArray(request) ? request : [request]
-    const documentNode = parseGraphqlQuery(postData[0].query)
-    const firstOperationDefinition = documentNode.definitions.find(
-      (def) => def.kind === "OperationDefinition"
-    ) as OperationDefinitionNode
-    const field = firstOperationDefinition.selectionSet.selections.find(
-      (selection) => selection.kind === "Field"
-    ) as FieldNode
-    const operationName =
-      firstOperationDefinition.name?.value || field?.name.value
+    let operationName
+    let operation: OperationType
 
-    if (!operationName) {
-      throw new Error("Operation name could not be determined")
+    if (postData[0].query) {
+      const documentNode = parseGraphqlQuery(postData[0].query)
+      const firstOperationDefinition = documentNode.definitions.find(
+        (def) => def.kind === "OperationDefinition"
+      ) as OperationDefinitionNode
+      const field = firstOperationDefinition.selectionSet.selections.find(
+        (selection) => selection.kind === "Field"
+      ) as FieldNode
+      operationName = firstOperationDefinition.name?.value || field?.name.value
+
+      if (!operationName) {
+        throw new Error("Operation name could not be determined")
+      }
+
+      operation = firstOperationDefinition?.operation
+    } else {
+      operationName = postData[0].operationName
+
+      if (!operationName) {
+        throw new Error("Operation name could not be determined")
+      }
+
+      // Can be either query or mutation here, we don't know
+      operation = "unknown"
     }
 
     return {
       operationName,
-      operation: firstOperationDefinition?.operation,
+      operation,
     }
   } catch (e) {
     return null


### PR DESCRIPTION
## Description

Thanks to this [commit](https://github.com/warrenday/graphql-network-inspector/commit/f87a6312dc7b40d9a58cee687f38432a673927a9), the extension now supports GET persisted queries.  While GET requests allow the browser to use HTTP caching, persisted queries can also be made with POST requests.

This PR adds the support to persisted queries made with POST requests.

## Screenshot

- The color can be changed. 
- The new `persisted` type is because a persisted query made as a POST can be either a query or a mutation.

![CleanShot 2023-03-14 at 12 01 24@2x](https://user-images.githubusercontent.com/26422481/225064216-496bc1f3-0442-4994-b09e-48c39548f050.png)

## Checklist

- [ ] Unit/Integration tests added
- [ ] POST persisted queries are now supported

Closes https://github.com/warrenday/graphql-network-inspector/issues/71
