### PR TITLE
feat(request): support to persisted queries encoded variables

### DIFF
--- a/src/containers/Main/Main.test.tsx
+++ b/src/containers/Main/Main.test.tsx
@@ -91,7 +91,7 @@ describe("Main", () => {
       expect(getByText(/getMovie/i)).toBeInTheDocument()
     })
 
-    expect(queryAllByRole("row")).toHaveLength(7)
+    expect(queryAllByRole("row")).toHaveLength(8)
   })
 
   it("renders correct values for each column within the table", async () => {
@@ -188,7 +188,7 @@ describe("Main", () => {
       triggerOnNavigated()
     })
 
-    expect(queryAllByRole("row")).toHaveLength(7)
+    expect(queryAllByRole("row")).toHaveLength(8)
   })
 
   it("filters network data with the given search query", async () => {
@@ -238,7 +238,7 @@ describe("Main", () => {
     })
 
     expect(filterInput.value).toBe("getmovie")
-    expect(queryAllByRole("row")).toHaveLength(6)
+    expect(queryAllByRole("row")).toHaveLength(7)
     queryAllByRole("row").forEach((row, i) => {
       // First row is header
       if (i !== 0) {
@@ -274,6 +274,22 @@ describe("Main", () => {
       if (i !== 0) {
         expect(row).toHaveTextContent("getMovie")
       }
+    })
+  })
+
+  it("extracts variables from extensions", async () => {
+    const { getByText, getByTestId } = render(<Main />)
+
+    await waitFor(() => {
+      expect(getByText(/hasUnseenAnnouncements/i)).toBeInTheDocument()
+    })
+
+    fireEvent.click(getByText(/hasUnseenAnnouncements/i))
+
+    expect(getByTestId("network-tabs")).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(getByText('Variables')).toBeInTheDocument()
     })
   })
 })

--- a/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
@@ -52,7 +52,7 @@ export const RequestView = (props: IRequestViewProps) => {
       {requests.map((request, index) => {
         return (
           <SingleRequestView
-            key={request.query}
+            key={request.id}
             request={request}
             autoFormat={autoFormat}
             index={shouldDisplayRequestIndex && index + 1}

--- a/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
@@ -12,12 +12,28 @@ import {
 } from "@/hooks/useRequestViewSections"
 import { CaretIcon } from "../../../components/Icons/CaretIcon"
 
-const isVariablesPopulated = (request: IGraphqlRequestBody) => {
-  return Object.keys(request.variables || {}).length > 0
+const isVariablesPopulated = (variables: Record<string, unknown>) => {
+  return Object.keys(variables || {}).length > 0
 }
 
 const isExtensionsPopulated = (request: IGraphqlRequestBody) => {
   return Object.keys(request.extensions || {}).length > 0
+}
+
+const getVariables = ({ variables, extensions }: IGraphqlRequestBody) => {
+  if (variables) {
+    return variables
+  }
+
+  if (extensions && 'variables' in extensions && typeof extensions.variables == 'string') {
+    try {
+      return JSON.parse(atob(extensions.variables))
+    } catch (e) {
+      return null
+    }
+  }
+
+  return null
 }
 
 interface IRequestViewProps {
@@ -59,7 +75,8 @@ const SingleRequestView = (props: SingleRequestViewProps) => {
   const { request, autoFormat, index, numberOfRequests } = props
 
   const displayQuery = !!request.query
-  const displayVariables = isVariablesPopulated(request)
+  const variables = getVariables(request)
+  const displayVariables = isVariablesPopulated(variables)
   const displayExtensions = isExtensionsPopulated(request)
 
   return (
@@ -71,7 +88,7 @@ const SingleRequestView = (props: SingleRequestViewProps) => {
         {displayVariables && (
           <CopyButton
             label="Copy Vars"
-            textToCopy={safeJson.stringify(request.variables, undefined, 2)}
+            textToCopy={safeJson.stringify(variables, undefined, 2)}
           />
         )}
         {displayExtensions && (
@@ -99,7 +116,7 @@ const SingleRequestView = (props: SingleRequestViewProps) => {
         {displayVariables && (
           <RequestViewSection type="variables" title="Variables">
             <CodeView
-              text={safeJson.stringify(request.variables, undefined, 2)}
+              text={safeJson.stringify(variables, undefined, 2)}
               language={"json"}
               className="px-6"
             />

--- a/src/helpers/graphqlHelpers.ts
+++ b/src/helpers/graphqlHelpers.ts
@@ -4,6 +4,7 @@ import gql from "graphql-tag"
 export type OperationType = "query" | "mutation" | "subscription" | "persisted"
 
 export interface IGraphqlRequestBody {
+  id: string
   query: string
   variables?: Record<string, unknown>
   extensions?: Record<string, unknown>
@@ -71,7 +72,7 @@ export const parseGraphqlQuery = (queryString: any) => {
 
 const parseGraphqlGetRequest = (
   details: chrome.devtools.network.Request
-): IGraphqlRequestBody[] | null => {
+): Omit<IGraphqlRequestBody, 'id'>[] | null => {
   const queryParam = details.request.queryString.find(
     (qs) => qs.name === "query"
   )
@@ -141,7 +142,7 @@ const parseGraphqlPostRequest = (
 
 export const parseGraphqlRequest = (
   details: chrome.devtools.network.Request
-): IGraphqlRequestBody[] | null => {
+): Omit<IGraphqlRequestBody, 'id'>[] | null => {
   switch (details.request.method) {
     case "GET":
       return parseGraphqlGetRequest(details)

--- a/src/helpers/graphqlHelpers.ts
+++ b/src/helpers/graphqlHelpers.ts
@@ -5,8 +5,8 @@ export type OperationType = "query" | "mutation" | "subscription" | "persisted"
 
 export interface IGraphqlRequestBody {
   query: string
-  variables?: object
-  extensions?: object
+  variables?: Record<string, unknown>
+  extensions?: Record<string, unknown>
 }
 
 export type OperationDetails = {

--- a/src/hooks/useNetworkMonitor.ts
+++ b/src/hooks/useNetworkMonitor.ts
@@ -4,6 +4,7 @@ import {
   getPrimaryOperation,
   parseGraphqlRequest,
   OperationDetails,
+  IGraphqlRequestBody,
 } from "../helpers/graphqlHelpers"
 import { onRequestFinished, getHAR } from "../services/networkMonitor"
 
@@ -16,10 +17,7 @@ export type NetworkRequest = {
   request: {
     primaryOperation: OperationDetails
     headers: Header[]
-    body: {
-      query: string
-      variables?: Record<string, unknown>
-    }[]
+    body: IGraphqlRequestBody[]
     headersSize: number
     bodySize: number
   }
@@ -58,7 +56,10 @@ export const useNetworkMonitor = (): [NetworkRequest[], () => void] => {
           request: {
             primaryOperation,
             headers: details.request.headers,
-            body: graphqlRequestBody,
+            body: graphqlRequestBody.map(request => ({
+              id: uuid(),
+              ...request,
+            })),
             headersSize: details.request.headersSize,
             bodySize: details.request.bodySize,
           },

--- a/src/hooks/useNetworkMonitor.ts
+++ b/src/hooks/useNetworkMonitor.ts
@@ -18,7 +18,7 @@ export type NetworkRequest = {
     headers: Header[]
     body: {
       query: string
-      variables?: object
+      variables?: Record<string, unknown>
     }[]
     headersSize: number
     bodySize: number

--- a/src/mocks/mock-requests.ts
+++ b/src/mocks/mock-requests.ts
@@ -7,10 +7,12 @@ const createRequest = ({
   response,
 }: {
   request: {
-    query: string
-    variables: object
+    query?: string
+    operationName?: string
+    variables?: Record<string, unknown>
+    extensions?: Record<string, unknown>
   }[]
-  response: object
+  response: Record<string, unknown>
 }) => {
   return {
     time: 1099.4580000406131,
@@ -38,9 +40,11 @@ const createRequest = ({
       method: "POST",
       postData: {
         text: JSON.stringify(
-          request.map(({ query, variables }) => ({
-            query: dedent(query),
+          request.map(({ query, variables, extensions, operationName }) => ({
+            query: query && dedent(query),
+            operationName,
             variables,
+            extensions,
           }))
         ),
       },
@@ -422,6 +426,25 @@ export const mockRequests = [
             ],
           },
         },
+      },
+    },
+  }),
+  createRequest({
+    request: [
+      {
+        operationName: 'hasUnseenAnnouncements',
+        extensions: {
+          persistedQuery: {
+            version: 1,
+            sha256Hash: "ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38",
+          },
+          variables: btoa('{"language":"pt"}'),
+        },
+      },
+    ],
+    response: {
+      data: {
+        hasUnseenAnnouncements: true,
       },
     },
   }),


### PR DESCRIPTION
## Description

1. Some support for persisted queries out of the box like trying to decode the variables by default

## Screenshot

![Screenshot from 2023-04-07 20-34-31](https://user-images.githubusercontent.com/8618687/230692194-3e5ac3c2-017d-4dbf-a15c-28d52774c814.png)

## Checklist

- [x] Displays correctly with both dark and light mode (see useTheme.ts)
- [x] Unit/Integration tests added
