### PR TITLE
fallback for parsing form data

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "GraphQL Network Inspector",
-  "version": "{{package_version}}",
+  "version": "1.0",
   "description": "Simple and clean network inspector for GraphQL",
   "icons": {
     "128": "icon.png"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "GraphQL Network Inspector",
-  "version": "1.0",
+  "version": "{{package_version}}",
   "description": "Simple and clean network inspector for GraphQL",
   "icons": {
     "128": "icon.png"

--- a/src/helpers/graphqlHelpers.test.ts
+++ b/src/helpers/graphqlHelpers.test.ts
@@ -2,6 +2,7 @@ import {
   getPrimaryOperation,
   getErrorMessages,
   parseGraphqlRequest,
+  parseMultipartFormData,
 } from "./graphqlHelpers"
 
 describe("GraphQL Helpers", () => {
@@ -618,6 +619,42 @@ describe("GraphQL Helpers", () => {
         })
       )
       expect(errorMessages).toEqual(["First Error", "Second Error"])
+    })
+  })
+
+  describe("parseMultiPartFormData", () => {
+    it("parses a multipart/form-data payload", () => {
+      const formDataPayload = `
+      ------WebKitFormBoundaryDKVAqIzxvy7rDWjN
+      Content-Disposition: form-data; name="operations"
+      
+      {"operationName":"ReadTextFile","query":"mutation ReadTextFile($file: File!) {\n  readTextFile(file: $file)\n}","variables":{"file":null}}
+      ------WebKitFormBoundaryDKVAqIzxvy7rDWjN
+      Content-Disposition: form-data; name="map"
+      
+      {"0":["variables.file"]}
+      ------WebKitFormBoundaryDKVAqIzxvy7rDWjN
+      Content-Disposition: form-data; name="0"; filename="cat.jpeg"
+      Content-Type: image/jpeg
+      
+      
+      ------WebKitFormBoundaryDKVAqIzxvy7rDWjN--
+    `
+
+      const output = parseMultipartFormData(
+        "----WebKitFormBoundaryDKVAqIzxvy7rDWjN",
+        formDataPayload
+      )
+
+      expect(output).toEqual({
+        operations: {
+          operationName: "ReadTextFile",
+          query:
+            "mutation ReadTextFile($file: File!) {  readTextFile(file: $file)}",
+          variables: { file: null },
+        },
+        map: { "0": ["variables.file"] },
+      })
     })
   })
 })

--- a/src/helpers/graphqlHelpers.ts
+++ b/src/helpers/graphqlHelpers.ts
@@ -72,7 +72,7 @@ export const parseGraphqlQuery = (queryString: any) => {
 
 const parseGraphqlGetRequest = (
   details: chrome.devtools.network.Request
-): Omit<IGraphqlRequestBody, 'id'>[] | null => {
+): Omit<IGraphqlRequestBody, "id">[] | null => {
   const queryParam = details.request.queryString.find(
     (qs) => qs.name === "query"
   )
@@ -118,14 +118,12 @@ const parseGraphqlGetRequest = (
 const parseGraphqlPostRequest = (
   details: chrome.devtools.network.Request
 ): IGraphqlRequestBody[] | null => {
-  const requestBody = details.request.postData?.text
-
-  if (!requestBody) {
-    return null
-  }
-
   try {
-    const requestPayload = JSON.parse(requestBody)
+    const requestPayload = extractGraphQLPayloadFromRequest(details)
+    if (!requestPayload) {
+      return null
+    }
+
     const requestPayloads = Array.isArray(requestPayload)
       ? requestPayload
       : [requestPayload]
@@ -142,7 +140,7 @@ const parseGraphqlPostRequest = (
 
 export const parseGraphqlRequest = (
   details: chrome.devtools.network.Request
-): Omit<IGraphqlRequestBody, 'id'>[] | null => {
+): Omit<IGraphqlRequestBody, "id">[] | null => {
   switch (details.request.method) {
     case "GET":
       return parseGraphqlGetRequest(details)
@@ -197,17 +195,114 @@ export const getPrimaryOperationForGetRequest = (
   return null
 }
 
-export const getPrimaryOperationForPostRequest = (
-  details: chrome.devtools.network.Request
-): OperationDetails | null => {
-  const requestBody = details.request.postData?.text
+/**
+ * Parse a multipart/form-data request payload
+ * and return a map of the form data.
+ *
+ * Here is an example form data payload:
+ *
+ * ```text
+ * -----------------------------7da24f2e50046
+ * Content-Disposition: form-data; name="operations"
+ *
+ * {"query":"mutation($file: Upload!) { uploadFile(file: $file) { id } }","variables":{"file":null}}
+ * -----------------------------7da24f2e50046
+ * Content-Disposition: form-data; name="map"
+ *
+ * {"0":["variables.file"]}
+ * -----------------------------7da24f2e50046
+ * ```
+ *
+ * @param boundary boundary value of the multipart/form-data content-type header
+ * @param formDataString the form data request payload
+ * @returns
+ */
+export const parseMultipartFormData = (
+  boundary: string,
+  formDataString: string
+) => {
+  // Split on the form boundary
+  const parts = formDataString.split(boundary)
+  const result: Record<string, string> = {}
 
+  // Process each part
+  for (let part of parts) {
+    // Trim and remove trailing dashes
+    const trimmedPart = part.trim().replace(/-+$/, "")
+
+    // Ignore empty parts
+    if (trimmedPart === "" || trimmedPart === "--") {
+      continue
+    }
+
+    // Extract the header and body
+    const [header, ...bodyParts] = trimmedPart.split("\n")
+    const body = bodyParts.join("\n").trim()
+
+    // Extract the name from the header
+    const nameMatch = header.match(/name="([^"]*)"/)
+    if (!nameMatch) {
+      continue
+    }
+
+    const name = nameMatch[1]
+    try {
+      result[name] = JSON.parse(body.replace(/\n/g, ""))
+    } catch (e) {}
+  }
+
+  return result
+}
+
+/**
+ * Extract the GraphQL request from the request payload.
+ *
+ * This is usually just a stringified JSON object, but in the case
+ * of multipart/form-data or application/x-www-form-urlencoded, this
+ * will need to be parsed differently.
+ *
+ * Either way we will end up with an object that contains the GraphQL
+ * operationName, query, and variables.
+ *
+ */
+const extractGraphQLPayloadFromRequest = (
+  details: chrome.devtools.network.Request
+) => {
+  const requestBody = details.request.postData?.text
   if (!requestBody) {
     return null
   }
 
   try {
-    const request = JSON.parse(requestBody)
+    // First just assume it's a JSON object
+    return JSON.parse(requestBody)
+  } catch (e) {
+    // Otherwise, check the content-type header to figure out how we proceed
+    const contentTypeHeader = details.request.headers.find((header) => {
+      return header.name.toLowerCase() === "content-type"
+    })
+    if (!contentTypeHeader) {
+      return
+    }
+
+    const isFormData = contentTypeHeader.value.includes("multipart/form-data")
+    const boundary = contentTypeHeader.value.split("boundary=")[1]
+    if (isFormData && boundary) {
+      const formData = parseMultipartFormData(boundary, requestBody)
+      return formData.operations
+    }
+  }
+}
+
+export const getPrimaryOperationForPostRequest = (
+  details: chrome.devtools.network.Request
+): OperationDetails | null => {
+  try {
+    const request = extractGraphQLPayloadFromRequest(details)
+    if (!request) {
+      return null
+    }
+
     const postData = Array.isArray(request) ? request : [request]
     let operationName
     let operation: OperationType


### PR DESCRIPTION
It's possible to post graphql requests using form-data. In this case parsing the request body as JSON will fail.

Instead, if JSON.parse fails, we can fallback to checking the content-type header and choosing to parse as form-data using a new custom function that parses the payload.

<img width="706" alt="Screenshot 2023-05-18 at 17 38 03" src="https://github.com/warrenday/graphql-network-inspector/assets/2871038/974932da-32a1-4659-b945-336f27abaab3">