### PR TITLE
fix(request): try to use persisted queries variables when request.var…

### DIFF
--- a/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
@@ -21,7 +21,7 @@ const isExtensionsPopulated = (request: IGraphqlRequestBody) => {
 }
 
 const getVariables = ({ variables, extensions }: IGraphqlRequestBody) => {
-  if (variables) {
+  if (variables && isVariablesPopulated(variables)) {
     return variables
   }
 


### PR DESCRIPTION
## Description

- I was testing the new changes in real use cases. I noticed that some implementations as the apollo persisted queries send both extensions.variables and variables together. So I added some support to try to use the extensions.variables if the variables is an empty object.

## Screenshot

![Screenshot from 2023-06-09 21-12-38](https://github.com/warrenday/graphql-network-inspector/assets/8618687/40a8fe1d-8132-40a2-aa8c-e18663b22d49)

## Checklist

- [x] Displays correctly with both dark and light mode (see useTheme.ts)
- [ ] Unit/Integration tests added
