### PR TITLE
Make different section collapsible

### DIFF
--- a/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/RequestView.tsx
@@ -83,6 +83,7 @@ const SingleRequestView = (props: ISingleRequestViewProps) => {
   const { request, autoFormat, index, numberOfRequests, onShare } = props
 
   const displayQuery = !!request.query
+  const requestId = request.id
   const variables = getVariables(request)
   const displayVariables = isVariablesPopulated(variables)
   const displayExtensions = isExtensionsPopulated(request)
@@ -109,38 +110,43 @@ const SingleRequestView = (props: ISingleRequestViewProps) => {
       </div>
 
       <div className="flex flex-col">
-        {displayQuery && (
-          <RequestViewSection
-            type="query"
-            title={"Query" + (index ? ` (${index}/${numberOfRequests})` : "")}
-          >
-            <CodeView
-              text={request.query}
-              language={"graphql"}
-              autoFormat={autoFormat}
-              className="px-6"
-            />
-          </RequestViewSection>
-        )}
-        {displayVariables && (
-          <RequestViewSection type="variables" title="Variables">
-            <CodeView
-              text={safeJson.stringify(variables, undefined, 2)}
-              language={"json"}
-              className="px-6"
-            />
-          </RequestViewSection>
-        )}
-        {displayExtensions && (
-          <RequestViewSection type="extensions" title="Extensions">
-            <CodeView
-              text={safeJson.stringify(request.extensions, undefined, 2)}
-              language={"json"}
-              autoFormat={autoFormat}
-              className="px-6"
-            />
-          </RequestViewSection>
-        )}
+        <RequestViewSection type='request' requestId={requestId} title={`Request${(index ? ` (${index}/${numberOfRequests})` : "")}`}>
+          {displayQuery && (
+            <RequestViewSection
+              type="query"
+              title={"Query" + (index ? ` (${index}/${numberOfRequests})` : "")}
+              requestId={requestId}
+              level={1}
+            >
+              <CodeView
+                text={request.query}
+                language={"graphql"}
+                autoFormat={autoFormat}
+                className="px-6"
+              />
+            </RequestViewSection>
+          )}
+          {displayVariables && (
+            <RequestViewSection type="variables" title="Variables" requestId={requestId} level={1}
+            >
+              <CodeView
+                text={safeJson.stringify(variables, undefined, 2)}
+                language={"json"}
+                className="px-6"
+              />
+            </RequestViewSection>
+          )}
+          {displayExtensions && (
+            <RequestViewSection type="extensions" title="Extensions" requestId={requestId} level={1}>
+              <CodeView
+                text={safeJson.stringify(request.extensions, undefined, 2)}
+                language={"json"}
+                autoFormat={autoFormat}
+                className="px-6"
+              />
+            </RequestViewSection>
+          )}
+        </RequestViewSection>
       </div>
     </PanelSection>
   )
@@ -149,19 +155,24 @@ const SingleRequestView = (props: ISingleRequestViewProps) => {
 interface IRequestViewSectionProps {
   type: RequestViewSectionType
   title: string
+  requestId: string
+  level?: number
 }
 
 const RequestViewSection: FC<IRequestViewSectionProps> = (props) => {
-  const { type, title, children } = props
+  const { type, title, requestId, children, level } = props
   const { collapsedSections, setIsSectionCollapsed } = useRequestViewSections()
-  const isCollapsed = !!collapsedSections[type]
+  const keyForMap = `${type}-${requestId}`
+
+  const isCollapsed = !!collapsedSections[keyForMap]
 
   const handleToggleView = () => {
-    setIsSectionCollapsed(type, !collapsedSections[type])
+    setIsSectionCollapsed(keyForMap, !collapsedSections[keyForMap])
   }
+  const classNameForLevel = `ml-${(level ?? 0) * 4}`
 
   return (
-    <div>
+    <div className={classNameForLevel}>
       <button
         className="select-none w-full px-4 py-3 outline-[#2f80ed]"
         onClick={handleToggleView}

--- a/src/hooks/useRequestViewSections.tsx
+++ b/src/hooks/useRequestViewSections.tsx
@@ -1,11 +1,11 @@
 import { useState, createContext, useContext } from "react"
 
-export type RequestViewSectionType = "query" | "variables" | "extensions"
+export type RequestViewSectionType = "query" | "variables" | "extensions" | 'request'
 
 const RequestViewSectionsContext = createContext<{
-  collapsedSections: Partial<Record<RequestViewSectionType, boolean>>
+  collapsedSections: Partial<Record<string, boolean>>
   setIsSectionCollapsed: (
-    sectionId: RequestViewSectionType,
+    sectionId: string,
     isCollapsed: boolean
   ) => void
 }>({
@@ -15,11 +15,11 @@ const RequestViewSectionsContext = createContext<{
 
 export const RequestViewSectionsProvider: React.FC = ({ children }) => {
   const [collapsedSections, setCollapsedSections] = useState(
-    {} as Partial<Record<RequestViewSectionType, boolean>>
+    {} as Partial<Record<string, boolean>>
   )
 
   function setIsSectionCollapsed(
-    sectionId: RequestViewSectionType,
+    sectionId: string,
     isCollapsed: boolean
   ) {
     setCollapsedSections({


### PR DESCRIPTION
## Description

This PR will add collapsible feature to different parts of request.
Currently when we collapse the query for 1 request, it will collapse for all. With this PR we will be only hiding the section on which we clicked.

The root cause of bug was that we were saving if section is collapsed using query, variable and extension as the key. With these PR we will add request id to key as well.
`variable` -> `variable-<request_id>`

Second major change is, in case of multiple graphql queries displayed in one request we will partitioning each queries. See image

## Screenshot


https://github.com/warrenday/graphql-network-inspector/assets/27822551/f24d32de-d911-492b-8947-f429a66d319f

<img width="817" alt="Screenshot 2024-04-03 at 9 42 14 PM" src="https://github.com/warrenday/graphql-network-inspector/assets/27822551/b778544e-e250-49f1-af5d-81f30a33ea3b">

<img width="680" alt="Screenshot 2024-04-03 at 9 48 09 PM" src="https://github.com/warrenday/graphql-network-inspector/assets/27822551/a13e2b6c-269e-400c-b48b-97b345f5d1ef">



## Checklist

- [X] Displays correctly with both dark and light mode (see useTheme.ts)
- [X] Unit/Integration tests added
