### PR TITLE
automatically parse and display JWT headers on double click

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
   <h1>GraphQL Network Inspector</h1>
   <h3>A better network inspector for viewing and debugging GraphQL requests.</h3>
   <img alt="MIT License" src="https://img.shields.io/github/license/warrenday/graphql-network-inspector" />
-  <a href="https://twitter.com/warrenjday">
-    <img alt="Twitter" src="https://img.shields.io/twitter/url.svg?label=%40warrenjday&style=social&url=https%3A%2F%2Ftwitter.com%2Fwarrenjday" />
-  </a>
   <a href="https://github.com/sponsors/warrenday">
     <img alt="GitHub Sponsors" src="https://img.shields.io/github/sponsors/warrenday">
   </a>
@@ -21,6 +18,20 @@ The plugin is available for both Chrome and Firefox:
 1. [Chrome Webstore](https://chrome.google.com/webstore/detail/graphql-network-inspector/ndlbedplllcgconngcnfmkadhokfaaln)
 
 2. [Firefox Addons](https://addons.mozilla.org/en-US/firefox/addon/graphql-network-inspector)
+
+## Features
+
+We provide a number of productivity features to help you debug and understand your GraphQL requests:
+
+- Automatically parse and display requests as GraphQL queries.
+- Support for query batching, displaying each query individually.
+- Export requests to re-run and share with https://www.graphdev.app
+
+Some shortcuts you may find useful:
+
+- Click any header to copy to clipboard.
+- Double click any JWT token header to both decode and copy to clipboard.
+- Press `Cmd/Ctrl + F` to open the full search panel.
 
 ## Issue with extension not loading
 
@@ -52,6 +63,12 @@ This will also cache files in the `build` so you can load the directory as an un
 PRs are welcome! The best way to do this is to first fork the repository, create a branch and open a pull request back to this repository.
 
 If you want to add a large feature please first raise an issue to discuss. This avoids wasted effort.
+
+## Sponsors
+
+GraphQL Network Inspector is proudly sponsored by:
+
+- The Guild https://the-guild.dev
 
 ## License
 

--- a/src/containers/NetworkPanel/HeaderView/HeaderList.tsx
+++ b/src/containers/NetworkPanel/HeaderView/HeaderList.tsx
@@ -1,6 +1,8 @@
 import { useMarkSearch } from "@/hooks/useMark"
 import { IHeader } from "@/hooks/useNetworkMonitor"
-import useCopy from "../../../hooks/useCopy"
+import useCopy from "@/hooks/useCopy"
+import parseAuthHeader from "./parseAuthHeader"
+import { useState } from "react"
 
 interface IHeadersProps {
   headers: IHeader[]
@@ -9,19 +11,52 @@ interface IHeadersProps {
 const HeaderListItem = (props: { header: IHeader }) => {
   const { header } = props
   const { isCopied, copy } = useCopy()
+  const [parsedValue, setParsedValue] = useState<string | null>(null)
 
-  const handleClick = (header: IHeader) => {
+  /**
+   * Copy the header value as-is to the clipboard
+   *
+   */
+  const copyHeader = (header: IHeader) => {
     copy(`"${header.name}": "${header.value}"`)
+  }
+
+  /**
+   * To automatically parse JWTs the user can double click.
+   *
+   * If the header is a valid JWT the value will be parsed
+   * and copied. Double clicking again will reverse this action.
+   *
+   */
+  const parseAndCopyHeader = (header: IHeader) => {
+    if (!header.value) {
+      return
+    }
+
+    // If value already parsed, double click will clear it.
+    if (parsedValue) {
+      setParsedValue(null)
+      copy(header.value)
+      return
+    }
+
+    // Parse the header and copy the parsed value
+    const parsed = parseAuthHeader(header)
+    if (parsed) {
+      setParsedValue(parsed)
+      copy(parsed)
+    }
   }
 
   return (
     <li className="p-0 m-0 w-fit relative">
       <button
-        onClick={() => handleClick(header)}
+        onClick={() => copyHeader(header)}
+        onDoubleClick={() => parseAndCopyHeader(header)}
         className="text-left dark:text-gray-300 px-3 py-0.5 rounded-md w-fit cursor-pointer hover:bg-gray-300 dark:hover:bg-gray-700"
       >
         <span className="font-bold">{header.name}: </span>
-        <span className="break-all">{header.value}</span>
+        <span className="break-all">{parsedValue || header.value}</span>
       </button>
       {isCopied && (
         <div className="rounded-md px-1.5 py-0.5 font-bold text-white bg-blue-400 dark:bg-blue-600 absolute left-2 -top-4">

--- a/src/containers/NetworkPanel/HeaderView/parseAuthHeader.test.ts
+++ b/src/containers/NetworkPanel/HeaderView/parseAuthHeader.test.ts
@@ -1,0 +1,48 @@
+import parseAuthHeader from "./parseAuthHeader"
+
+describe("parseAuthHeader", () => {
+  it("parses a bearer token header", () => {
+    const header = {
+      name: "Authorization",
+      value:
+        "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+    }
+
+    const result = parseAuthHeader(header)
+    expect(result).toEqual(
+      '{"sub":"1234567890","name":"John Doe","iat":1516239022}'
+    )
+  })
+
+  it("parses a non-bearer token header", () => {
+    const header = {
+      name: "Authorization",
+      value:
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+    }
+
+    const result = parseAuthHeader(header)
+    expect(result).toEqual(
+      '{"sub":"1234567890","name":"John Doe","iat":1516239022}'
+    )
+  })
+
+  it("returns undefined if the header value is empty", () => {
+    const header = {
+      name: "Authorization",
+    }
+
+    const result = parseAuthHeader(header)
+    expect(result).toBeUndefined()
+  })
+
+  it("returns undefined if the header value is not a valid JWT", () => {
+    const header = {
+      name: "Authorization",
+      value: "invalid",
+    }
+
+    const result = parseAuthHeader(header)
+    expect(result).toBeUndefined()
+  })
+})

--- a/src/containers/NetworkPanel/HeaderView/parseAuthHeader.ts
+++ b/src/containers/NetworkPanel/HeaderView/parseAuthHeader.ts
@@ -1,0 +1,33 @@
+import { IHeader } from "@/hooks/useNetworkMonitor"
+import * as jwt from "@/helpers/jwt"
+import * as safeJson from "@/helpers/safeJson"
+
+const decodeHeaderValue = (headerValue: string) => {
+  try {
+    if (headerValue.startsWith("Bearer ")) {
+      return jwt.decode(headerValue.substring("Bearer ".length))
+    }
+
+    return jwt.decode(headerValue)
+  } catch (e) {
+    return
+  }
+}
+
+/**
+ * Attempt to parse an auth header as a JWT
+ * @param header
+ * @returns
+ */
+const parseAuthHeader = (header: IHeader) => {
+  if (!header.value) {
+    return
+  }
+
+  const decodedValue = decodeHeaderValue(header.value)
+  if (decodedValue) {
+    return safeJson.stringify(decodedValue)
+  }
+}
+
+export default parseAuthHeader

--- a/src/helpers/jwt.test.ts
+++ b/src/helpers/jwt.test.ts
@@ -1,0 +1,26 @@
+import * as jwt from "./jwt"
+
+describe("jwt.decodeJWT", () => {
+  it("decodes a JWT token", () => {
+    const token =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+
+    const decoded = jwt.decode(token)
+
+    expect(decoded).toEqual({
+      sub: "1234567890",
+      name: "John Doe",
+      iat: 1516239022,
+    })
+  })
+
+  it("fails to decode an invalid JWT token", () => {
+    const token = "not-a-token"
+
+    try {
+      jwt.decode(token)
+    } catch (error) {
+      expect((error as Error).message).toBe("Invalid token")
+    }
+  })
+})

--- a/src/helpers/jwt.ts
+++ b/src/helpers/jwt.ts
@@ -1,0 +1,25 @@
+/**
+ * Decode a JWT
+ * @param token the JWT token
+ * @returns the decoded JWT data
+ */
+const decode = (token: string) => {
+  try {
+    const base64Url = token.split(".")[1] // Get the payload part
+    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/") // Convert to base64
+    const jsonPayload = decodeURIComponent(
+      atob(base64)
+        .split("")
+        .map((c) => {
+          return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2)
+        })
+        .join("")
+    )
+
+    return JSON.parse(jsonPayload)
+  } catch (error) {
+    throw new Error("Invalid token")
+  }
+}
+
+export { decode }

--- a/src/mocks/mock-requests.ts
+++ b/src/mocks/mock-requests.ts
@@ -21,7 +21,8 @@ const createRequest = ({
       headers: [
         {
           name: "Authorization",
-          value: "Bearer fe0e8768-3b2f-4f63-983d-1a74c26dde1e",
+          value:
+            "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
         },
         {
           name: "access-control-allow-credentials",


### PR DESCRIPTION
## Description

On double click, parse, display and copy valid JWT headers. Both with or without Bearer.

Also added noted to readme.

## Checklist

- [x] Displays correctly with both dark and light mode (see useTheme.ts)
- [x] Unit/Integration tests added
