### PR TITLE
Handle compression

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "tailwindcss": "^3.0.23",
     "typescript": "^4.0.3",
     "util": "^0.12.5",
-    "utility-types": "^3.11.0"
+    "utility-types": "^3.11.0",
+    "web-streams-polyfill": "^4.0.0"
   },
   "_resolutions_comment_": "https://stackoverflow.com/a/71855781/2573621",
   "resolutions": {

--- a/src/helpers/gzip.ts
+++ b/src/helpers/gzip.ts
@@ -1,0 +1,53 @@
+export type CompressionType = 'gzip' | 'deflate'
+
+const rawToUint8Array = (raw: chrome.webRequest.UploadData[]): Uint8Array => {
+  const arrays = raw
+    .filter((data) => data.bytes)
+    .map((data) => new Uint8Array(data.bytes!))
+
+  const totalLength = arrays.reduce((acc, arr) => acc + arr.length, 0)
+  const result = new Uint8Array(totalLength)
+
+  let offset = 0
+  for (const arr of arrays) {
+    result.set(arr, offset)
+    offset += arr.length
+  }
+
+  return result
+}
+
+const stringToUint8Array = (str: string): Uint8Array => {
+  const array = new Uint8Array(str.length)
+  for (let i = 0; i < str.length; i++) {
+    array[i] = str.charCodeAt(i)
+  }
+  return array
+}
+
+export const decompress = async (
+  raw: chrome.webRequest.UploadData[] | string,
+  compressionType: CompressionType
+) => {
+  const uint8Array =
+    typeof raw === 'string' ? stringToUint8Array(raw) : rawToUint8Array(raw)
+
+  const readableStream = new Response(uint8Array).body
+  if (!readableStream) {
+    throw new Error('Failed to create readable stream from Uint8Array.')
+  }
+
+  // Pipe through the decompression stream
+  const decompressedStream = readableStream.pipeThrough(
+    new (window as any).DecompressionStream(compressionType)
+  )
+
+  console.log({ raw, uint8Array })
+
+  // Convert the decompressed stream back to a Uint8Array
+  const decompressedArrayBuffer = await new Response(
+    decompressedStream
+  ).arrayBuffer()
+
+  return new Uint8Array(decompressedArrayBuffer)
+}

--- a/src/helpers/gzip.ts
+++ b/src/helpers/gzip.ts
@@ -42,8 +42,6 @@ export const decompress = async (
     new (window as any).DecompressionStream(compressionType)
   )
 
-  console.log({ raw, uint8Array })
-
   // Convert the decompressed stream back to a Uint8Array
   const decompressedArrayBuffer = await new Response(
     decompressedStream

--- a/src/hooks/useLatestState.ts
+++ b/src/hooks/useLatestState.ts
@@ -1,0 +1,35 @@
+import { useCallback, useRef, useState } from 'react'
+
+/**
+ * Has a matching API to useState, but also provides a getter to always
+ * access the latest state.
+ *
+ * This is handled through a ref, so it's safe to use in callbacks or
+ * other places where the state might be stale.
+ *
+ */
+const useLatestState = <T>(initialState: T) => {
+  const [state, setState] = useState(initialState)
+  const latestStateRef = useRef(state)
+
+  // This getter can be used to always access the latest state
+  const getState = () => latestStateRef.current
+
+  const setStateWrapper = useCallback(
+    (newState: T | ((state: T) => T)) => {
+      setState((prevState) => {
+        const updatedState =
+          typeof newState === 'function'
+            ? (newState as any)(prevState)
+            : newState
+        latestStateRef.current = updatedState
+        return updatedState
+      })
+    },
+    [setState]
+  )
+
+  return [state, setStateWrapper, getState] as const
+}
+
+export default useLatestState

--- a/yarn.lock
+++ b/yarn.lock
@@ -9565,6 +9565,11 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
+web-streams-polyfill@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-4.0.0.tgz#74cedf168339ee6e709532f76c49313a8c7acdac"
+  integrity sha512-0zJXHRAYEjM2tUfZ2DiSOHAa2aw1tisnnhU3ufD57R8iefL+DcdJyRBRyJpG+NUimDgbTI/lH+gAE1PAvV3Cgw==
+
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"


### PR DESCRIPTION
## Description

Following https://github.com/warrenday/graphql-network-inspector/issues/142 we now support request compression/decompression.

All natively supported via browser APIs.

Adding decompression support forced a few methods to become async, requiring a refactor of the useNetworkMonitor.