### PR TITLE
Extract `operationName` for GET persisted operations

### DIFF
--- a/src/helpers/networkHelpers.test.ts
+++ b/src/helpers/networkHelpers.test.ts
@@ -123,6 +123,42 @@ describe('networkHelpers.getRequestBodyFromUrl', () => {
       },
     })
   })
+
+  it('returns the request body for a persisted query with operationName in query parameters', () => {
+    const operationName = 'someGqlOperation'
+
+    const extensions = {
+      persistedQuery: {
+        sha256Hash: '12345',
+      },
+    }
+    const variables = {
+      id: '1',
+    }
+
+    const baseUrl = 'https://your-graphql-endpoint.com/graphql'
+    // Encode the query parameters
+    const params = new URLSearchParams({
+      operationName,
+      variables: encodeURIComponent(JSON.stringify(variables)),
+      extensions: encodeURIComponent(JSON.stringify(extensions)),
+    })
+    const url = `${baseUrl}?${params.toString()}`
+
+    const body = getRequestBodyFromUrl(url)
+    expect(body).toMatchObject({
+      query: '',
+      operationName: 'someGqlOperation',
+      variables: {
+        id: '1',
+      },
+      extensions: {
+        persistedQuery: {
+          sha256Hash: '12345',
+        },
+      },
+    })
+  })
 })
 
 describe('networkHelpers.matchWebAndNetworkRequest', () => {

--- a/src/helpers/networkHelpers.ts
+++ b/src/helpers/networkHelpers.ts
@@ -271,6 +271,7 @@ export const getRequestBodyFromUrl = (url: string): IGraphqlRequestBody => {
   if (persistedQuery) {
     return {
       query: '',
+      operationName: operationName ?? '',
       extensions: decodedExtensions ? JSON.parse(decodedExtensions) : undefined,
       variables: decodedVariables ? JSON.parse(decodedVariables) : undefined,
     }


### PR DESCRIPTION
## Description

PR to address issue https://github.com/warrenday/graphql-network-inspector/issues/148

Set `operationName` in `IGraphqlRequestBody` for GET persisted queries. It was missing and is needed to correctly display it in the Query/Mutation column.

## Screenshot

Provide a screenshot or gif of the new feature in both dark and light mode.

## Checklist

- [x] Displays correctly with both dark and light mode (see useTheme.ts)
- [x] Unit/Integration tests added

I added a test to check that it does return correctly the operation name for persisted get requests.
However the project `Main.test.tsx` files uses `mockRequests` which contains only POST requests, therefore this bug was not detectable with the current test suite. I think adding tests for GET requests too is bigger than the scope of this fix and should be done by a regular maintainer of the project.
