### PR TITLE
Make subscription work for rails apps

### DIFF
--- a/src/hooks/useWebSocketNetworkMonitor.test.ts
+++ b/src/hooks/useWebSocketNetworkMonitor.test.ts
@@ -319,7 +319,7 @@ describe('useWebSocketNetworkMonitor', () => {
                 identifier:
                   '{"channel":"GraphqlChannel","channelId":"1932245fcc6"}',
                 message: {
-                  data: { reviewAdded: { stars: 4, episode: 'CLONE_WARS' } },
+                  reviewAdded: { stars: 4, episode: 'CLONE_WARS' },
                 },
               }),
               time: 1234,

--- a/src/hooks/useWebSocketNetworkMonitor.test.ts
+++ b/src/hooks/useWebSocketNetworkMonitor.test.ts
@@ -1,17 +1,17 @@
-import { renderHook } from "@testing-library/react-hooks"
-import { DeepPartial } from "utility-types"
-import { useWebSocketNetworkMonitor } from "./useWebSocketNetworkMonitor"
-import { getHAR } from "../services/networkMonitor"
+import { renderHook } from '@testing-library/react-hooks'
+import { DeepPartial } from 'utility-types'
+import { useWebSocketNetworkMonitor } from './useWebSocketNetworkMonitor'
+import { getHAR } from '../services/networkMonitor'
 
-jest.mock("../services/networkMonitor")
+jest.mock('../services/networkMonitor')
 const mockGetHAR = getHAR as jest.MockedFunction<any>
 
-describe("useWebSocketNetworkMonitor", () => {
+describe('useWebSocketNetworkMonitor', () => {
   beforeEach(() => {
     jest.resetAllMocks()
   })
 
-  it("polls the HAR log and returns the websocket requests", async () => {
+  it('polls the HAR log and returns the websocket requests', async () => {
     mockGetHAR.mockResolvedValue({
       entries: [
         {
@@ -19,42 +19,42 @@ describe("useWebSocketNetworkMonitor", () => {
           // should not appear in output
         },
         {
-          _resourceType: "websocket",
+          _resourceType: 'websocket',
           request: {
-            url: "ws://localhost:4000/graphql",
-            method: "GET",
+            url: 'ws://localhost:4000/graphql',
+            method: 'GET',
             headers: [
-              { name: "RequestHeader1", value: "Value1" },
-              { name: "RequestHeader2", value: "Value2" },
+              { name: 'RequestHeader1', value: 'Value1' },
+              { name: 'RequestHeader2', value: 'Value2' },
             ],
           },
           response: {
             status: 101,
             headers: [
-              { name: "ResponseHeader1", value: "Value1" },
-              { name: "ResponseHeader2", value: "Value2" },
+              { name: 'ResponseHeader1', value: 'Value1' },
+              { name: 'ResponseHeader2', value: 'Value2' },
             ],
           },
           _webSocketMessages: [
             {
               data: JSON.stringify({
                 payload: {
-                  data: { reviewAdded: { stars: 4, episode: "NEWHOPE" } },
+                  data: { reviewAdded: { stars: 4, episode: 'NEWHOPE' } },
                 },
               }),
               opcode: 1,
               time: 1234,
-              type: "receive",
+              type: 'receive',
             },
             {
               data: JSON.stringify({
                 payload: {
-                  data: { reviewAdded: { stars: 4, episode: "NEWHOPE" } },
+                  data: { reviewAdded: { stars: 4, episode: 'NEWHOPE' } },
                 },
               }),
               opcode: 1,
               time: 1234,
-              type: "receive",
+              type: 'receive',
             },
           ],
         },
@@ -69,20 +69,20 @@ describe("useWebSocketNetworkMonitor", () => {
 
     expect(result.current[0]).toEqual([
       {
-        id: "subscription-1",
+        id: 'subscription-1',
         status: 101,
-        url: "ws://localhost:4000/graphql",
-        method: "GET",
+        url: 'ws://localhost:4000/graphql',
+        method: 'GET',
         request: {
           headers: [
-            { name: "RequestHeader1", value: "Value1" },
-            { name: "RequestHeader2", value: "Value2" },
+            { name: 'RequestHeader1', value: 'Value1' },
+            { name: 'RequestHeader2', value: 'Value2' },
           ],
         },
         response: {
           headers: [
-            { name: "ResponseHeader1", value: "Value1" },
-            { name: "ResponseHeader2", value: "Value2" },
+            { name: 'ResponseHeader1', value: 'Value1' },
+            { name: 'ResponseHeader2', value: 'Value2' },
           ],
         },
         messages: [
@@ -91,74 +91,74 @@ describe("useWebSocketNetworkMonitor", () => {
               payload: {
                 data: {
                   reviewAdded: {
-                    episode: "NEWHOPE",
+                    episode: 'NEWHOPE',
                     stars: 4,
                   },
                 },
-              }
+              },
             },
             time: 1234,
-            type: "receive",
+            type: 'receive',
           },
           {
             data: {
               payload: {
                 data: {
                   reviewAdded: {
-                    episode: "NEWHOPE",
+                    episode: 'NEWHOPE',
                     stars: 4,
                   },
                 },
-              }
+              },
             },
             time: 1234,
-            type: "receive",
+            type: 'receive',
           },
         ],
       },
     ])
   })
 
-  it("only returns sent requests which contain a valid graphql query", async () => {
+  it('only returns sent requests which contain a valid graphql query', async () => {
     mockGetHAR.mockResolvedValue({
       entries: [
         {
-          _resourceType: "websocket",
+          _resourceType: 'websocket',
           request: {
-            url: "ws://localhost:4000/graphql",
-            method: "GET",
+            url: 'ws://localhost:4000/graphql',
+            method: 'GET',
             headers: [
-              { name: "RequestHeader1", value: "Value1" },
-              { name: "RequestHeader2", value: "Value2" },
+              { name: 'RequestHeader1', value: 'Value1' },
+              { name: 'RequestHeader2', value: 'Value2' },
             ],
           },
           response: {
             status: 101,
             headers: [
-              { name: "ResponseHeader1", value: "Value1" },
-              { name: "ResponseHeader2", value: "Value2" },
+              { name: 'ResponseHeader1', value: 'Value1' },
+              { name: 'ResponseHeader2', value: 'Value2' },
             ],
           },
           _webSocketMessages: [
             {
               data: JSON.stringify({
                 payload: {
-                  query: "invalid query",
+                  query: 'invalid query',
                 },
               }),
               opcode: 1,
               time: 1234,
-              type: "send",
+              type: 'send',
             },
             {
               data: JSON.stringify({
                 payload: {
-                  query: "query users { id }",
+                  query: 'query users { id }',
                 },
               }),
               opcode: 1,
               time: 1234,
-              type: "send",
+              type: 'send',
             },
           ],
         },
@@ -173,31 +173,198 @@ describe("useWebSocketNetworkMonitor", () => {
 
     expect(result.current[0]).toEqual([
       {
-        id: "subscription-0",
+        id: 'subscription-0',
         status: 101,
-        url: "ws://localhost:4000/graphql",
-        method: "GET",
+        url: 'ws://localhost:4000/graphql',
+        method: 'GET',
         request: {
           headers: [
-            { name: "RequestHeader1", value: "Value1" },
-            { name: "RequestHeader2", value: "Value2" },
+            { name: 'RequestHeader1', value: 'Value1' },
+            { name: 'RequestHeader2', value: 'Value2' },
           ],
         },
         response: {
           headers: [
-            { name: "ResponseHeader1", value: "Value1" },
-            { name: "ResponseHeader2", value: "Value2" },
+            { name: 'ResponseHeader1', value: 'Value1' },
+            { name: 'ResponseHeader2', value: 'Value2' },
           ],
         },
         messages: [
           {
             data: {
               payload: {
-                query: "query users { id }",
+                query: 'query users { id }',
               },
             },
             time: 1234,
-            type: "send",
+            type: 'send',
+          },
+        ],
+      },
+    ])
+  })
+
+  it('accepts sent messages for rails channel', async () => {
+    mockGetHAR.mockResolvedValue({
+      entries: [
+        {
+          _resourceType: 'websocket',
+          request: {
+            url: 'ws://localhost:4000/graphql',
+            method: 'GET',
+            headers: [
+              { name: 'RequestHeader1', value: 'Value1' },
+              { name: 'RequestHeader2', value: 'Value2' },
+            ],
+          },
+          response: {
+            status: 101,
+            headers: [
+              { name: 'ResponseHeader1', value: 'Value1' },
+              { name: 'ResponseHeader2', value: 'Value2' },
+            ],
+          },
+          _webSocketMessages: [
+            {
+              data: JSON.stringify({
+                command: 'message',
+                identifier:
+                  '{"channel":"GraphqlChannel","channelId":"1932245fcc6"}',
+                data: JSON.stringify({
+                  query: 'query users { id }',
+                  variables: {},
+                  operationName: 'Users',
+                  action: 'execute',
+                }),
+              }),
+              opcode: 1,
+              time: 1234,
+              type: 'send',
+            },
+          ],
+        },
+      ],
+    } as DeepPartial<chrome.devtools.network.HARLog>)
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useWebSocketNetworkMonitor()
+    )
+
+    await waitForNextUpdate()
+
+    expect(result.current[0]).toEqual([
+      {
+        id: 'subscription-0',
+        status: 101,
+        url: 'ws://localhost:4000/graphql',
+        method: 'GET',
+        request: {
+          headers: [
+            { name: 'RequestHeader1', value: 'Value1' },
+            { name: 'RequestHeader2', value: 'Value2' },
+          ],
+        },
+        response: {
+          headers: [
+            { name: 'ResponseHeader1', value: 'Value1' },
+            { name: 'ResponseHeader2', value: 'Value2' },
+          ],
+        },
+        messages: [
+          {
+            data: {
+              command: 'message',
+              identifier: {
+                channel: 'GraphqlChannel',
+                channelId: '1932245fcc6',
+              },
+              data: {
+                query: 'query users { id }',
+                variables: {},
+                operationName: 'Users',
+                action: 'execute',
+              },
+            },
+            time: 1234,
+            type: 'send',
+          },
+        ],
+      },
+    ])
+  })
+
+  it('accepts received messages for rails channel', async () => {
+    mockGetHAR.mockResolvedValue({
+      entries: [
+        {
+          _resourceType: 'websocket',
+          request: {
+            url: 'ws://localhost:4000/graphql',
+            method: 'GET',
+            headers: [
+              { name: 'RequestHeader1', value: 'Value1' },
+              { name: 'RequestHeader2', value: 'Value2' },
+            ],
+          },
+          response: {
+            status: 101,
+            headers: [
+              { name: 'ResponseHeader1', value: 'Value1' },
+              { name: 'ResponseHeader2', value: 'Value2' },
+            ],
+          },
+          _webSocketMessages: [
+            {
+              data: JSON.stringify({
+                identifier:
+                  '{"channel":"GraphqlChannel","channelId":"1932245fcc6"}',
+                message: {
+                  data: { reviewAdded: { stars: 4, episode: 'CLONE_WARS' } },
+                },
+              }),
+              time: 1234,
+              type: 'received',
+            },
+          ],
+        },
+      ],
+    } as DeepPartial<chrome.devtools.network.HARLog>)
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useWebSocketNetworkMonitor()
+    )
+
+    await waitForNextUpdate()
+
+    expect(result.current[0]).toEqual([
+      {
+        id: 'subscription-0',
+        status: 101,
+        url: 'ws://localhost:4000/graphql',
+        method: 'GET',
+        request: {
+          headers: [
+            { name: 'RequestHeader1', value: 'Value1' },
+            { name: 'RequestHeader2', value: 'Value2' },
+          ],
+        },
+        response: {
+          headers: [
+            { name: 'ResponseHeader1', value: 'Value1' },
+            { name: 'ResponseHeader2', value: 'Value2' },
+          ],
+        },
+        messages: [
+          {
+            data: {
+              identifier: {
+                channel: 'GraphqlChannel',
+                channelId: '1932245fcc6',
+              },
+              data: { reviewAdded: { stars: 4, episode: 'CLONE_WARS' } },
+            },
+            time: 1234,
+            type: 'received',
           },
         ],
       },
@@ -208,10 +375,10 @@ describe("useWebSocketNetworkMonitor", () => {
     mockGetHAR.mockResolvedValue({
       entries: [
         {
-          _resourceType: "websocket",
+          _resourceType: 'websocket',
           request: {
-            url: "ws://localhost:4000/graphql",
-            method: "GET",
+            url: 'ws://localhost:4000/graphql',
+            method: 'GET',
             headers: [],
           },
           response: {
@@ -222,10 +389,10 @@ describe("useWebSocketNetworkMonitor", () => {
         },
         // Ignored as url does not contain "graphql"
         {
-          _resourceType: "websocket",
+          _resourceType: 'websocket',
           request: {
-            url: "ws://localhost:4000/some-other-url",
-            method: "GET",
+            url: 'ws://localhost:4000/some-other-url',
+            method: 'GET',
             headers: [],
           },
           response: {
@@ -238,17 +405,20 @@ describe("useWebSocketNetworkMonitor", () => {
     } as DeepPartial<chrome.devtools.network.HARLog>)
 
     const { result, waitForNextUpdate } = renderHook(() =>
-      useWebSocketNetworkMonitor({ isEnabled: true, urlFilter: "some-other-url" })
+      useWebSocketNetworkMonitor({
+        isEnabled: true,
+        urlFilter: 'some-other-url',
+      })
     )
 
     await waitForNextUpdate()
 
     expect(result.current[0]).toEqual([
       {
-        id: "subscription-1",
+        id: 'subscription-1',
         status: 101,
-        url: "ws://localhost:4000/some-other-url",
-        method: "GET",
+        url: 'ws://localhost:4000/some-other-url',
+        method: 'GET',
         request: {
           headers: [],
         },
@@ -267,12 +437,12 @@ describe("useWebSocketNetworkMonitor", () => {
 
     const { rerender, waitForNextUpdate } = renderHook(
       (props) => useWebSocketNetworkMonitor(props),
-      { initialProps: { isEnabled: false, urlFilter: "graphql" } }
+      { initialProps: { isEnabled: false, urlFilter: 'graphql' } }
     )
 
     expect(mockGetHAR).not.toHaveBeenCalled()
 
-    rerender({ isEnabled: true, urlFilter: "graphql" })
+    rerender({ isEnabled: true, urlFilter: 'graphql' })
     await waitForNextUpdate()
 
     expect(mockGetHAR).toHaveBeenCalledTimes(1)

--- a/src/hooks/useWebSocketNetworkMonitor.ts
+++ b/src/hooks/useWebSocketNetworkMonitor.ts
@@ -1,9 +1,9 @@
-import { useCallback, useState } from "react"
-import { getHAR } from "../services/networkMonitor"
-import useInterval from "./useInterval"
-import { IHeader } from "@/helpers/networkHelpers"
-import * as safeJson from "@/helpers/safeJson"
-import { isGraphqlQuery } from "../helpers/graphqlHelpers"
+import { useCallback, useState } from 'react'
+import { getHAR } from '../services/networkMonitor'
+import useInterval from './useInterval'
+import { IHeader } from '@/helpers/networkHelpers'
+import * as safeJson from '@/helpers/safeJson'
+import { isGraphqlQuery } from '../helpers/graphqlHelpers'
 
 export interface IWebSocketMessage {
   /**
@@ -42,7 +42,7 @@ interface IWebSocketHAREntryMessage {
 }
 
 interface WebSocketHAREntry {
-  _resourceType: "websocket"
+  _resourceType: 'websocket'
   _webSocketMessages: IWebSocketHAREntryMessage[]
   request: {
     url: string
@@ -50,28 +50,67 @@ interface WebSocketHAREntry {
 }
 
 const isWebSocketEntry = (entry: any): entry is WebSocketHAREntry => {
-  return entry._resourceType === "websocket"
+  return entry._resourceType === 'websocket'
 }
 
-const isGraphQLWebsocketEntry = (entry: WebSocketHAREntry, urlFilter: string) => {
+const isGraphQLWebsocketEntry = (
+  entry: WebSocketHAREntry,
+  urlFilter: string
+) => {
   return urlFilter ? entry.request.url.includes(urlFilter) : true
 }
 
+interface IMessageData {
+  payload: {
+    query: string
+  }
+}
+
+interface IRailsChannelSendMessageData {
+  command: string
+  identifier: string
+  data: string
+}
+
+interface IRailsChannelReceiveMessageData {
+  identifier: string
+  message: {
+    data: Record<string, any>
+  }
+}
+
+type MessageData =
+  | IMessageData
+  | IRailsChannelSendMessageData
+  | IRailsChannelReceiveMessageData
+
 const isGraphQLPayload = (
   type: string,
-  payload?: Record<string, any>
-): payload is {} => {
-  if (!payload) {
+  messageData?: MessageData
+): Record<string, any> | boolean => {
+  if (!messageData) {
     return false
   }
 
-  if (type === "send") {
-    const hasQuery = "query" in payload
-    return hasQuery && isGraphqlQuery(payload.query)
+  if ('payload' in messageData) {
+    if (type === 'send') {
+      const hasQuery = 'query' in messageData.payload
+      if (hasQuery && isGraphqlQuery(messageData.payload.query)) {
+        return messageData.payload
+      }
+    }
+
+    if (type === 'receive' && 'data' in messageData.payload) {
+      return messageData.payload
+    }
   }
 
-  if (type === "receive") {
-    return "data" in payload
+  if (isIRailsChannelSendMessageData(messageData)) {
+    return isGraphqlQuery(JSON.parse(messageData.data).query)
+  }
+
+  if (isIRailsChannelReceiveMessageData(messageData)) {
+    return !!messageData.message.data
   }
 
   return false
@@ -82,25 +121,28 @@ const prepareWebSocketRequests = (
   options: { urlFilter: string }
 ): IWebSocketNetworkRequest[] => {
   return har.entries.flatMap((entry, i) => {
-    if (isWebSocketEntry(entry) && isGraphQLWebsocketEntry(entry, options.urlFilter)) {
+    if (
+      isWebSocketEntry(entry) &&
+      isGraphQLWebsocketEntry(entry, options.urlFilter)
+    ) {
       const websocketEntry: IWebSocketNetworkRequest = {
         id: `subscription-${i}`,
         status: entry.response.status,
         url: entry.request.url,
         method: entry.request.method,
-        messages: entry._webSocketMessages.flatMap(message => {
-          const messageData =
-            safeJson.parse<Record<string, any>>(message.data) || undefined
+        messages: entry._webSocketMessages.flatMap((message) => {
+          const messageData = safeJson.parse(message.data) as
+            | MessageData
+            | undefined
 
-          const payload = messageData?.payload
-          if (!messageData || !isGraphQLPayload(message.type, payload)) {
+          if (!messageData || !isGraphQLPayload(message.type, messageData)) {
             return []
           }
 
           return {
             type: message.type,
             time: message.time,
-            data: messageData,
+            data: formatMessageData(messageData, message.type),
           }
         }),
         request: {
@@ -115,6 +157,45 @@ const prepareWebSocketRequests = (
       return []
     }
   })
+}
+
+const formatMessageData = (messageData: MessageData, type: string) => {
+  if (isIMessageData(messageData)) {
+    return messageData
+  }
+
+  if (isIRailsChannelSendMessageData(messageData)) {
+    return {
+      command: messageData.command,
+      identifier: JSON.parse(messageData.identifier),
+      data: JSON.parse(messageData.data),
+    }
+  }
+
+  if (isIRailsChannelReceiveMessageData(messageData)) {
+    return {
+      identifier: JSON.parse(messageData.identifier),
+      data: messageData.message.data,
+    }
+  }
+
+  return messageData
+}
+
+function isIMessageData(data: MessageData): data is IMessageData {
+  return 'payload' in data
+}
+
+function isIRailsChannelSendMessageData(
+  data: MessageData
+): data is IRailsChannelSendMessageData {
+  return 'command' in data && 'identifier' in data && 'data' in data
+}
+
+function isIRailsChannelReceiveMessageData(
+  data: MessageData
+): data is IRailsChannelReceiveMessageData {
+  return 'identifier' in data && 'message' in data && !('command' in data)
 }
 
 interface IUseWebSocketNetworkOptions {
@@ -135,7 +216,9 @@ export const useWebSocketNetworkMonitor = (
 
   const fetchWebSocketRequests = useCallback(async () => {
     const har = await getHAR()
-    const websocketRequests = prepareWebSocketRequests(har, { urlFilter: options.urlFilter })
+    const websocketRequests = prepareWebSocketRequests(har, {
+      urlFilter: options.urlFilter,
+    })
     setWebSocketRequests(websocketRequests)
   }, [setWebSocketRequests, options.urlFilter])
 

--- a/src/hooks/useWebSocketNetworkMonitor.ts
+++ b/src/hooks/useWebSocketNetworkMonitor.ts
@@ -110,7 +110,7 @@ const isGraphQLPayload = (
   }
 
   if (isIRailsChannelReceiveMessageData(messageData)) {
-    return !!messageData.message.data
+    return !!messageData.message
   }
 
   return false
@@ -175,7 +175,7 @@ const formatMessageData = (messageData: MessageData, type: string) => {
   if (isIRailsChannelReceiveMessageData(messageData)) {
     return {
       identifier: JSON.parse(messageData.identifier),
-      data: messageData.message.data,
+      data: messageData.message,
     }
   }
 

--- a/src/mocks/mock-requests.ts
+++ b/src/mocks/mock-requests.ts
@@ -798,7 +798,7 @@ export const mockRequests: IMockRequest[] = [
         data: {
           identifier: '{"channel":"GraphqlChannel","channelId":"1932245fcc6"}',
           message: {
-            data: { reviewAdded: { stars: 4, episode: 'CLONE_WARS' } },
+            reviewAdded: { stars: 4, episode: 'CLONE_WARS' },
           },
         },
         opcode: 1,


### PR DESCRIPTION
## Description
The subscription feature does not work on default rails apps since they have a different pattern to support. I'll leave a screenshot of what it looks like currently.
![image](https://github.com/user-attachments/assets/de814189-6632-47fe-b93e-1e3f8de71ad1)

This PR is meant to make all Rails apps compatible with the Rails ActionCable(the default way to use WebSockets with Ruby on Rails). You can find more [here](https://guides.rubyonrails.org/action_cable_overview.html).

PS: Sorry for the linter changes. But I ran the project linter, and it seems ok.

## Screenshot

There are no UI changes; I just changed the interceptor.

![image](https://github.com/user-attachments/assets/8ff0cd40-0d32-462d-b47f-e86fee8fca95)
![image](https://github.com/user-attachments/assets/f3f03b98-063e-48fc-b536-c46d8f70bf6b)


## Checklist

- [x] Displays correctly with both dark and light mode (see useTheme.ts)
- [x] Unit/Integration tests added
