### PR TITLE
fix: check method is get before check url

### DIFF
--- a/src/hooks/useNetworkMonitor.ts
+++ b/src/hooks/useNetworkMonitor.ts
@@ -121,7 +121,7 @@ export const useNetworkMonitor = (): [
 
   const handleBeforeRequest = useCallback(
     (details: chrome.webRequest.WebRequestBodyDetails) => {
-      if (urlHasFileExtension(details.url)) {
+      if (details.method === 'GET' && urlHasFileExtension(details.url)) {
         return
       }
 
@@ -145,7 +145,7 @@ export const useNetworkMonitor = (): [
 
   const handleBeforeSendHeaders = useCallback(
     async (details: chrome.webRequest.WebRequestHeadersDetails) => {
-      if (urlHasFileExtension(details.url)) {
+      if (details.method === 'GET' && urlHasFileExtension(details.url)) {
         return
       }
 
@@ -219,7 +219,7 @@ export const useNetworkMonitor = (): [
 
   const handleRequestFinished = useCallback(
     (details: chrome.devtools.network.Request) => {
-      if (urlHasFileExtension(details.request.url)) {
+      if (details.request.method === 'GET' && urlHasFileExtension(details.request.url)) {
         return
       }
 


### PR DESCRIPTION
## Description

Hi, I absolutely love this project—it’s been incredibly useful and well-crafted!
I've added a conditional check to ensure that GET requests are evaluated before determining if a URL is a static file. Generally, static file requests (like those with .json extensions) are made using the GET method. By prioritizing this check, it ensures that .json-ending GraphQL API requests (such as those used by Shopify APIs) are not mistakenly filtered out.

Let me know if you'd like any adjustments!

## Screenshot

Provide a screenshot or gif of the new feature in both dark and light mode.

## Checklist

- [ ] Displays correctly with both dark and light mode (see useTheme.ts)
- [ ] Unit/Integration tests added
