### PR TITLE
Remove extra dollar sign in curl command export

### DIFF
--- a/src/helpers/curlHelpers.test.ts
+++ b/src/helpers/curlHelpers.test.ts
@@ -105,7 +105,7 @@ describe('getNetworkCurl', () => {
       "curl 'https://api.example.com/graphql' \\\n" +
         "  -H 'content-type: application/json' \\\n" +
         '  -X POST \\\n' +
-        '  --data-raw $\'{"query":"query { test! }"}\''
+        '  --data-raw \'{"query":"query { test! }"}\''
     )
   })
 
@@ -162,7 +162,7 @@ describe('getNetworkCurl', () => {
         "  -H 'Content-Type: application/json' \\\n" +
         "  -H 'Authorization: Bearer token123' \\\n" +
         '  -X POST \\\n' +
-        '  --data-raw $\'{"query":"query TestQuery { test }","variables":{}}\''
+        '  --data-raw \'{"query":"query TestQuery { test }","variables":{}}\''
     )
   })
 
@@ -215,7 +215,7 @@ describe('getNetworkCurl', () => {
         "  -H 'content-type: application/json' \\\n" +
         "  -H 'authorization: Bearer token123' \\\n" +
         '  -X POST \\\n' +
-        '  --data-raw $\'{"query":"query { user { id name } }","variables":{"userId":"123"}}\''
+        '  --data-raw \'{"query":"query { user { id name } }","variables":{"userId":"123"}}\''
     )
   })
 
@@ -302,7 +302,7 @@ describe('getNetworkCurl', () => {
         "  -H 'content-type: application/json' \\\n" +
         "  -H 'authorization: Bearer token123' \\\n" +
         '  -X POST \\\n' +
-        '  --data-raw $\'{"query":"query { test }","variables":{}}\''
+        '  --data-raw \'{"query":"query { test }","variables":{}}\''
     )
   })
 })

--- a/src/helpers/curlHelpers.ts
+++ b/src/helpers/curlHelpers.ts
@@ -92,7 +92,7 @@ export const getNetworkCurl = async (
   // Add body with proper escaping
   if (chromeRequest.request.postData?.text) {
     const formattedBody = formatBody(chromeRequest.request.postData.text)
-    parts.push(`--data-raw $'${formattedBody}'`)
+    parts.push(`--data-raw '${formattedBody}'`)
   }
 
   return parts.join(' \\\n  ')


### PR DESCRIPTION
## Description

This PR removes an extra dollar sign that was added to the "Copy as cURL" command export. Demo of the bug below.

## Screenshot

https://www.loom.com/share/ab6d6b4ef4024c488f69c364d015ab60
