### PR TITLE
feat(multipart): support multipart payloads for @defer usage

### DIFF
--- a/src/containers/NetworkPanel/NetworkDetails/ResponseView.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/ResponseView.tsx
@@ -1,32 +1,115 @@
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
 import * as safeJson from "../../../helpers/safeJson"
 import { JsonView } from "@/components/CodeView"
 import { CopyButton } from "../../../components/CopyButton"
 import { ShareButton } from "../../../components/ShareButton"
+import { IResponseChunk } from "@/helpers/networkHelpers"
+import { mergeResponseChunks, formatIncrementalResponseTimeline } from "@/helpers/incrementalResponseHelpers"
 
 interface IResponseViewProps {
   response?: string
   collapsed?: number
   onShare?: () => void
+  chunks?: IResponseChunk[]
+  isStreaming?: boolean
 }
 
 export const ResponseView = (props: IResponseViewProps) => {
-  const { response, collapsed, onShare } = props
-  const { formattedJson, parsedResponse } = useMemo(() => {
+  const { response, collapsed, onShare, chunks, isStreaming } = props
+  const [viewMode, setViewMode] = useState<'merged' | 'timeline'>('merged')
+
+  const { formattedJson, parsedResponse, hasIncrementalData } = useMemo(() => {
+    // If we have chunks, merge them
+    if (chunks && chunks.length > 0) {
+      const { mergedData, hasIncrementalData } = mergeResponseChunks(chunks)
+
+      // Remove hasNext from the display (it's internal to incremental delivery)
+      const displayData = mergedData ? { ...mergedData } : {}
+      if (displayData.hasNext !== undefined) {
+        delete displayData.hasNext
+      }
+
+      return {
+        formattedJson: safeJson.stringify(displayData, undefined, 2),
+        parsedResponse: displayData,
+        hasIncrementalData,
+      }
+    }
+
+    // Otherwise, use the single response
     const parsedResponse = safeJson.parse(response) || {}
     return {
       formattedJson: safeJson.stringify(parsedResponse, undefined, 2),
       parsedResponse,
+      hasIncrementalData: false,
     }
-  }, [response])
+  }, [response, chunks])
+
+  const timeline = useMemo(() => {
+    if (chunks && chunks.length > 0) {
+      return formatIncrementalResponseTimeline(chunks)
+    }
+    return []
+  }, [chunks])
 
   return (
     <div className="relative p-4">
       <div className="absolute right-3 top-3 z-10 flex gap-2">
+        {hasIncrementalData && (
+          <>
+            <button
+              onClick={() => setViewMode('merged')}
+              className={`py-1.5 px-2.5 text-md font-semibold rounded-md ${
+                viewMode === 'merged'
+                  ? 'bg-blue-500 text-white'
+                  : 'bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-white'
+              }`}
+            >
+              Merged
+            </button>
+            <button
+              onClick={() => setViewMode('timeline')}
+              className={`py-1.5 px-2.5 text-md font-semibold rounded-md ${
+                viewMode === 'timeline'
+                  ? 'bg-blue-500 text-white'
+                  : 'bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-white'
+              }`}
+            >
+              Timeline ({chunks?.length || 0} chunks)
+            </button>
+          </>
+        )}
         {onShare && <ShareButton onClick={onShare} />}
         <CopyButton textToCopy={formattedJson} />
       </div>
-      <JsonView src={parsedResponse} collapsed={collapsed} />
+
+      {isStreaming && (
+        <div className="mb-3 px-2 py-1 bg-blue-50 dark:bg-blue-900 border border-blue-200 dark:border-blue-700 rounded text-xs text-blue-800 dark:text-blue-200 w-fit z-10 relative">
+          Incremental Response (@defer/@stream) - {chunks?.length || 0} chunk(s)
+        </div>
+      )}
+
+      {viewMode === 'merged' ? (
+        <JsonView src={parsedResponse} collapsed={collapsed} />
+      ) : (
+        <div className="space-y-4">
+          {timeline.map((item, index) => (
+            <div key={index} className="border border-gray-200 dark:border-gray-700 rounded p-3">
+              <div className="flex justify-between items-center mb-2 text-xs text-gray-600 dark:text-gray-400">
+                <span className="font-semibold">
+                  Chunk {item.chunkIndex + 1}
+                  {item.isIncremental && (
+                    <span className="ml-2 px-2 py-0.5 bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-200 rounded">
+                      Incremental
+                    </span>
+                  )}
+                </span>
+              </div>
+              <JsonView src={item.data || {}} collapsed={1} />
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/containers/NetworkPanel/NetworkDetails/index.tsx
+++ b/src/containers/NetworkPanel/NetworkDetails/index.tsx
@@ -24,6 +24,8 @@ export const NetworkDetails = (props: INetworkDetailsProps) => {
   const responseHeaders = data.response?.headers || []
   const requestBody = data.request.body
   const responseBody = data.response?.body
+  const responseChunks = data.response?.chunks
+  const isStreaming = data.response?.isStreaming
   const responseCollapsedCount = requestBody.length > 1 ? 3 : 2
   const tracing = useApolloTracing(responseBody)
   const [autoFormat, toggleAutoFormat] = useToggle()
@@ -86,6 +88,8 @@ export const NetworkDetails = (props: INetworkDetailsProps) => {
               onShare={isShareable ? handleShare : undefined}
               response={responseBody}
               collapsed={responseCollapsedCount}
+              chunks={responseChunks}
+              isStreaming={isStreaming}
             />
           ),
         },

--- a/src/helpers/incrementalResponseHelpers.test.ts
+++ b/src/helpers/incrementalResponseHelpers.test.ts
@@ -1,0 +1,319 @@
+import {
+  mergeIncrementalChunk,
+  mergeResponseChunks,
+  formatIncrementalResponseTimeline,
+} from './incrementalResponseHelpers'
+import { IResponseChunk } from './networkHelpers'
+
+describe('incrementalResponseHelpers', () => {
+  describe('mergeIncrementalChunk', () => {
+    it('merges data at a specific path', () => {
+      const baseResponse = {
+        data: {
+          user: {
+            id: '1',
+            name: 'John',
+          },
+        },
+      }
+
+      const chunk = {
+        data: { email: 'john@example.com' },
+        path: ['user'],
+      }
+
+      const result = mergeIncrementalChunk(baseResponse, chunk)
+
+      expect(result).toEqual({
+        data: {
+          user: {
+            id: '1',
+            name: 'John',
+            email: 'john@example.com',
+          },
+        },
+      })
+    })
+
+    it('merges data at root when path is empty', () => {
+      const baseResponse = {
+        data: {
+          user: { id: '1' },
+        },
+      }
+
+      const chunk = {
+        data: { extra: 'value' },
+        path: [],
+      }
+
+      const result = mergeIncrementalChunk(baseResponse, chunk)
+
+      expect(result).toEqual({
+        data: {
+          user: { id: '1' },
+          extra: 'value',
+        },
+      })
+    })
+
+    it('merges arrays at a specific path', () => {
+      const baseResponse = {
+        data: {
+          user: {
+            id: '1',
+            posts: [{ id: 'a' }],
+          },
+        },
+      }
+
+      const chunk = {
+        data: [{ id: 'b' }],
+        path: ['user', 'posts'],
+      }
+
+      const result = mergeIncrementalChunk(baseResponse, chunk)
+
+      expect(result).toEqual({
+        data: {
+          user: {
+            id: '1',
+            posts: [{ id: 'a' }, { id: 'b' }],
+          },
+        },
+      })
+    })
+
+    it('merges errors', () => {
+      const baseResponse = {
+        data: { user: { id: '1' } },
+        errors: [{ message: 'Error 1', path: ['user'] }],
+      }
+
+      const chunk = {
+        data: { email: 'test@example.com' },
+        path: ['user'],
+        errors: [{ message: 'Error 2', path: ['user', 'email'] }],
+      }
+
+      const result = mergeIncrementalChunk(baseResponse, chunk)
+
+      expect(result.errors).toHaveLength(2)
+      expect(result.errors[0].message).toBe('Error 1')
+      expect(result.errors[1].message).toBe('Error 2')
+    })
+
+    it('creates nested structure when path does not exist', () => {
+      const baseResponse = {
+        data: {},
+      }
+
+      const chunk = {
+        data: { title: 'Post 1' },
+        path: ['user', 'posts', 0],
+      }
+
+      const result = mergeIncrementalChunk(baseResponse, chunk)
+
+      expect(result).toEqual({
+        data: {
+          user: {
+            posts: [{ title: 'Post 1' }],
+          },
+        },
+      })
+    })
+  })
+
+  describe('mergeResponseChunks', () => {
+    it('returns empty result for no chunks', () => {
+      const result = mergeResponseChunks([])
+
+      expect(result).toEqual({
+        mergedData: null,
+        hasIncrementalData: false,
+        chunks: [],
+      })
+    })
+
+    it('returns single chunk data when only one chunk', () => {
+      const chunks: IResponseChunk[] = [
+        {
+          body: JSON.stringify({ data: { user: { id: '1' } } }),
+          timestamp: Date.now(),
+          isIncremental: false,
+        },
+      ]
+
+      const result = mergeResponseChunks(chunks)
+
+      expect(result.hasIncrementalData).toBe(false)
+      expect(result.mergedData).toEqual({ data: { user: { id: '1' } } })
+    })
+
+    it('merges multiple chunks with incremental array format', () => {
+      const chunks: IResponseChunk[] = [
+        {
+          body: JSON.stringify({
+            data: { user: { id: '1', name: 'John' } },
+            hasNext: true,
+          }),
+          timestamp: Date.now(),
+          isIncremental: false,
+        },
+        {
+          body: JSON.stringify({
+            incremental: [
+              {
+                data: { email: 'john@example.com' },
+                path: ['user'],
+              },
+            ],
+            hasNext: true,
+          }),
+          timestamp: Date.now(),
+          isIncremental: true,
+        },
+        {
+          body: JSON.stringify({
+            incremental: [
+              {
+                data: [{ title: 'Post 1' }],
+                path: ['user', 'posts'],
+              },
+            ],
+            hasNext: false,
+          }),
+          timestamp: Date.now(),
+          isIncremental: true,
+        },
+      ]
+
+      const result = mergeResponseChunks(chunks)
+
+      expect(result.hasIncrementalData).toBe(true)
+      expect(result.mergedData).toEqual({
+        data: {
+          user: {
+            id: '1',
+            name: 'John',
+            email: 'john@example.com',
+            posts: [{ title: 'Post 1' }],
+          },
+        },
+        hasNext: true,
+      })
+    })
+
+    it('merges multiple chunks with single incremental chunk format', () => {
+      const chunks: IResponseChunk[] = [
+        {
+          body: JSON.stringify({
+            data: { user: { id: '1' } },
+          }),
+          timestamp: Date.now(),
+          isIncremental: false,
+        },
+        {
+          body: JSON.stringify({
+            data: { email: 'john@example.com' },
+            path: ['user'],
+          }),
+          timestamp: Date.now(),
+          isIncremental: true,
+        },
+      ]
+
+      const result = mergeResponseChunks(chunks)
+
+      expect(result.hasIncrementalData).toBe(true)
+      expect(result.mergedData).toEqual({
+        data: {
+          user: {
+            id: '1',
+            email: 'john@example.com',
+          },
+        },
+      })
+    })
+
+    it('handles invalid JSON in chunks gracefully', () => {
+      const chunks: IResponseChunk[] = [
+        {
+          body: JSON.stringify({ data: { user: { id: '1' } } }),
+          timestamp: Date.now(),
+          isIncremental: false,
+        },
+        {
+          body: 'invalid json',
+          timestamp: Date.now(),
+          isIncremental: true,
+        },
+      ]
+
+      const result = mergeResponseChunks(chunks)
+
+      expect(result.hasIncrementalData).toBe(true)
+      expect(result.mergedData).toEqual({
+        data: { user: { id: '1' } },
+      })
+    })
+  })
+
+  describe('formatIncrementalResponseTimeline', () => {
+    it('returns empty array for no chunks', () => {
+      const result = formatIncrementalResponseTimeline([])
+      expect(result).toEqual([])
+    })
+
+    it('formats chunks into timeline format', () => {
+      const chunks: IResponseChunk[] = [
+        {
+          body: JSON.stringify({ data: { user: { id: '1' } } }),
+          timestamp: 1000,
+          isIncremental: false,
+        },
+        {
+          body: JSON.stringify({
+            incremental: [{ data: { email: 'test@example.com' }, path: ['user'] }],
+          }),
+          timestamp: 2000,
+          isIncremental: true,
+        },
+      ]
+
+      const result = formatIncrementalResponseTimeline(chunks)
+
+      expect(result).toHaveLength(2)
+      expect(result[0]).toEqual({
+        timestamp: 1000,
+        isIncremental: false,
+        data: { data: { user: { id: '1' } } },
+        chunkIndex: 0,
+      })
+      expect(result[1]).toEqual({
+        timestamp: 2000,
+        isIncremental: true,
+        data: {
+          incremental: [{ data: { email: 'test@example.com' }, path: ['user'] }],
+        },
+        chunkIndex: 1,
+      })
+    })
+
+    it('handles invalid JSON in timeline', () => {
+      const chunks: IResponseChunk[] = [
+        {
+          body: 'invalid json',
+          timestamp: 1000,
+          isIncremental: false,
+        },
+      ]
+
+      const result = formatIncrementalResponseTimeline(chunks)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].data).toEqual({})
+    })
+  })
+})

--- a/src/helpers/incrementalResponseHelpers.ts
+++ b/src/helpers/incrementalResponseHelpers.ts
@@ -1,0 +1,206 @@
+import { IResponseChunk } from './networkHelpers'
+import { parse } from './safeJson'
+import { IIncrementalResponse, IIncrementalDataChunk } from '../types'
+
+/**
+ * Get a value at a specific path in an object
+ * Path is an array like ['user', 'posts', 0, 'comments']
+ */
+function getValueAtPath(obj: any, path: (string | number)[]): any {
+  let current = obj
+  for (const key of path) {
+    if (current == null) return undefined
+    current = current[key]
+  }
+  return current
+}
+
+/**
+ * Set a value at a specific path in an object
+ * Path is an array like ['user', 'posts', 0, 'comments']
+ * Merges with existing value if present
+ */
+function setValueAtPath(obj: any, path: (string | number)[], value: any): void {
+  if (path.length === 0) {
+    return
+  }
+
+  let current = obj
+  for (let i = 0; i < path.length - 1; i++) {
+    const key = path[i]
+    if (!(key in current)) {
+      // Create array or object based on next key type
+      const nextKey = path[i + 1]
+      current[key] = typeof nextKey === 'number' ? [] : {}
+    }
+    current = current[key]
+  }
+
+  const lastKey = path[path.length - 1]
+  // Deep merge with existing value
+  const existingValue = current[lastKey]
+  if (existingValue !== undefined) {
+    current[lastKey] = deepMerge(existingValue, value)
+  } else {
+    current[lastKey] = value
+  }
+}
+
+/**
+ * Deep merge two objects, combining arrays and objects
+ */
+function deepMerge(target: any, source: any): any {
+  if (source === null || source === undefined) {
+    return target
+  }
+
+  if (target === null || target === undefined) {
+    return source
+  }
+
+  if (Array.isArray(target) && Array.isArray(source)) {
+    return [...target, ...source]
+  }
+
+  if (typeof target === 'object' && typeof source === 'object') {
+    const result = { ...target }
+    for (const key in source) {
+      if (key in result) {
+        result[key] = deepMerge(result[key], source[key])
+      } else {
+        result[key] = source[key]
+      }
+    }
+    return result
+  }
+
+  return source
+}
+
+/**
+ * Merge an incremental chunk into the base response
+ */
+export function mergeIncrementalChunk(
+  baseResponse: any,
+  chunk: IIncrementalDataChunk
+): any {
+  const result = { ...baseResponse }
+
+  // If chunk has a path, merge data at that path
+  if (chunk.path !== undefined && chunk.data !== undefined) {
+    if (chunk.path.length === 0) {
+      // Path is empty, merge at data root
+      result.data = deepMerge(result.data || {}, chunk.data)
+    } else {
+      // Path is relative to the data field in GraphQL responses
+      // So we need to prepend 'data' to the path
+      const fullPath = ['data', ...chunk.path]
+      setValueAtPath(result, fullPath, chunk.data)
+    }
+  }
+
+  // Merge errors if present
+  if (chunk.errors) {
+    result.errors = result.errors
+      ? [...result.errors, ...chunk.errors]
+      : chunk.errors
+  }
+
+  // Merge extensions if present
+  if (chunk.extensions) {
+    result.extensions = result.extensions
+      ? { ...result.extensions, ...chunk.extensions }
+      : chunk.extensions
+  }
+
+  return result
+}
+
+/**
+ * Merge all response chunks into a single complete response
+ * This handles @defer/@stream incremental delivery format
+ */
+export function mergeResponseChunks(chunks: IResponseChunk[]): {
+  mergedData: any
+  hasIncrementalData: boolean
+  chunks: IResponseChunk[]
+} {
+  if (chunks.length === 0) {
+    return {
+      mergedData: null,
+      hasIncrementalData: false,
+      chunks: [],
+    }
+  }
+
+  // Parse the first chunk as base response
+  const firstChunkData = parse<any>(chunks[0].body)
+  let mergedData = firstChunkData || {}
+
+  const hasIncrementalData = chunks.length > 1
+
+  // Process subsequent chunks
+  for (let i = 1; i < chunks.length; i++) {
+    const chunkData = parse<IIncrementalResponse | IIncrementalDataChunk>(
+      chunks[i].body
+    )
+
+    if (!chunkData) continue
+
+    // Handle incremental response format (with incremental array)
+    if ('incremental' in chunkData && chunkData.incremental) {
+      for (const incrementalChunk of chunkData.incremental) {
+        mergedData = mergeIncrementalChunk(mergedData, incrementalChunk)
+      }
+    }
+    // Handle single incremental chunk format
+    else if ('path' in chunkData) {
+      mergedData = mergeIncrementalChunk(
+        mergedData,
+        chunkData as IIncrementalDataChunk
+      )
+    }
+    // Handle full response format (merge everything)
+    else {
+      mergedData = deepMerge(mergedData, chunkData)
+    }
+  }
+
+  return {
+    mergedData,
+    hasIncrementalData,
+    chunks,
+  }
+}
+
+/**
+ * Format incremental response for display
+ * Shows the progression of data as chunks arrive
+ */
+export function formatIncrementalResponseTimeline(
+  chunks: IResponseChunk[]
+): Array<{
+  timestamp: number
+  isIncremental: boolean
+  data: any
+  chunkIndex: number
+}> {
+  const timeline: Array<{
+    timestamp: number
+    isIncremental: boolean
+    data: any
+    chunkIndex: number
+  }> = []
+
+  for (let i = 0; i < chunks.length; i++) {
+    const chunkData = parse(chunks[i].body)
+    timeline.push({
+      timestamp: chunks[i].timestamp,
+      isIncremental: chunks[i].isIncremental,
+      data: chunkData || {},
+      chunkIndex: i,
+    })
+  }
+
+  return timeline
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,30 @@ export interface IApolloServerExtensions {
   tracing?: IApolloServerTracing
 }
 
+// Incremental delivery (defer/stream) support
+export interface IIncrementalDataChunk {
+  data?: unknown
+  path?: (string | number)[]
+  label?: string
+  errors?: Array<{
+    message: string
+    path?: (string | number)[]
+  }>
+  extensions?: IApolloServerExtensions
+  hasNext?: boolean
+}
+
+export interface IIncrementalResponse {
+  data?: unknown
+  errors?: Array<{
+    message: string
+    path?: (string | number)[]
+  }>
+  extensions?: IApolloServerExtensions
+  hasNext: boolean
+  incremental?: IIncrementalDataChunk[]
+}
+
 export interface IApolloServerTracing {
   version: number
   startTime: string


### PR DESCRIPTION
## Description

Adds support for rendering multipart graphql payloads, for `@defer` usage in queries. This was not tested with @stream. It would cover the `@defer` portion of this issue: 

https://github.com/warrenday/graphql-network-inspector/issues/168

The issue does bring to question if there is a broader standard. What I know is that this will support deferred graphql requests that leverage the Apollo graphql gateway: https://www.apollographql.com/docs/graphos/routing/operations/defer. 

As of now, this chrome extension simply renders an empty object (see "before" screenshot below) when a multi part graphql response is in the mix. 

More specifically, this feature adds 2 buttons to the ResponseView:

* Merged - which provides a merged view of the incremental responses
* Timeline (X chunks) - which provides each response as it's own view

The majority of this pull request was implemented with Claude. I am absolutely open to changing any and everything and/or adding tests if you find any are missing, etc.

## Screenshot

### Before: 
<img width="1092" height="509" alt="Screenshot 2025-12-15 at 1 50 37 PM" src="https://github.com/user-attachments/assets/79542006-9628-41b2-91fe-19327d631ac6" />


### After:
Merged (dark):
<img width="1093" height="505" alt="Screenshot 2025-12-15 at 1 59 12 PM" src="https://github.com/user-attachments/assets/70d4443e-1136-42d5-8e96-86448a0ad91e" />

Timeline (dark):
<img width="1091" height="507" alt="Screenshot 2025-12-15 at 1 55 35 PM" src="https://github.com/user-attachments/assets/18bf0e9d-afc2-4f88-92d5-b602d7350d47" />

Merged (light):
<img width="1091" height="514" alt="Screenshot 2025-12-15 at 2 01 06 PM" src="https://github.com/user-attachments/assets/9100f326-8d0d-4ae6-9fb1-a5c789148084" />

Timeline (light):
<img width="1092" height="507" alt="Screenshot 2025-12-15 at 2 01 12 PM" src="https://github.com/user-attachments/assets/7d21dd07-27f5-4d14-86f0-ff239d34f639" />

## Checklist
- [x] Displays correctly with both dark and light mode (see useTheme.ts)
- [x] Unit/Integration tests added
